### PR TITLE
Rake tasks for ttnt

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ Or install it yourself as:
 
     $ gem install ttnt
 
+### Define rake tasks
+
+You can define TTNT rake tasks by following steps:
+
+1. `require 'ttnt/tasks'`
+2. Define `TTNT::TestTask` when defining `Rake::TestTask`
+
+Your `Rakefile` will look like this:
+
+```
+require 'rake/testtask'
+require 'ttnt/tasks'
+
+Rake::TestTask.new { |t|
+  t.libs << "test"
+  t.pattern = 'test/**/*_test.rb'
+  TTNT::TestTask.new(t)
+}
+```
+
 ## Requirements
 
 Developed and only tested under ruby version 2.2.1.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ Developed and only tested under ruby version 2.2.1.
 
 ### Produce test-to-code mapping for a given commit
 
+### Using rake task
+
+If you defined TTNT rake task as described above, you can run following command to produce test-to-code mapping:
+
+```
+$ rake ttnt:anchor
+```
+
+### Using ttnt-anchor executable
+
 This pre-computation is required to select tests later.
 
 Basically, you can substitute `ruby` command with `ttnt-anchor` command.

--- a/lib/ttnt/tasks.rb
+++ b/lib/ttnt/tasks.rb
@@ -1,0 +1,24 @@
+require 'rake/testtask'
+require 'ttnt/testtask'
+
+# https://github.com/bundler/bundler/blob/master/lib/bundler/gem_helper.rb
+module TTNT
+  class TaskHelper
+    include Rake::DSL if defined? Rake::DSL
+
+    def self.install_tasks
+      new.install
+    end
+
+    def install
+      namespace :ttnt do
+        desc 'Generate test-to-code mapping for current commit object'
+        task 'anchor' do
+          puts "Hello Rake!"
+        end
+      end
+    end
+  end
+end
+
+TTNT::TaskHelper.install_tasks

--- a/lib/ttnt/tasks.rb
+++ b/lib/ttnt/tasks.rb
@@ -4,7 +4,7 @@ require 'ttnt/testtask'
 require 'ttnt/test_selector'
 require 'rugged'
 
-# https://github.com/bundler/bundler/blob/master/lib/bundler/gem_helper.rb
+# Reference: https://github.com/bundler/bundler/blob/master/lib/bundler/gem_helper.rb
 module TTNT
   class TaskHelper
     include Rake::DSL if defined? Rake::DSL

--- a/lib/ttnt/tasks.rb
+++ b/lib/ttnt/tasks.rb
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require 'rake/file_list'
 require 'ttnt/testtask'
 
 # https://github.com/bundler/bundler/blob/master/lib/bundler/gem_helper.rb
@@ -14,7 +15,19 @@ module TTNT
       namespace :ttnt do
         desc 'Generate test-to-code mapping for current commit object'
         task 'anchor' do
-          puts "Hello Rake!"
+          # TODO: what if multiple test tasks are defined?
+          test_task = TTNT::TestTask.instances.first
+          test_files = []
+          test_files += test_task.test_files.to_a if test_task.test_files
+          test_files += Rake::FileList[test_task.pattern] if test_task.pattern
+
+          # TODO: properly regard run options defined for Rake::TestTask
+          gem_root = File.expand_path('..', File.dirname(File.expand_path(__FILE__)))
+          args = "-I#{gem_root} -r ttnt/anchor"
+          args += " -I#{test_task.libs.join(':')}" unless test_task.libs.empty?
+          test_files.each do |test_file|
+            ruby "#{args} #{test_file}"
+          end
         end
       end
     end

--- a/lib/ttnt/tasks.rb
+++ b/lib/ttnt/tasks.rb
@@ -1,6 +1,8 @@
 require 'rake/testtask'
 require 'rake/file_list'
 require 'ttnt/testtask'
+require 'ttnt/test_selector'
+require 'rugged'
 
 # https://github.com/bundler/bundler/blob/master/lib/bundler/gem_helper.rb
 module TTNT
@@ -27,6 +29,21 @@ module TTNT
           args += " -I#{test_task.libs.join(':')}" unless test_task.libs.empty?
           test_files.each do |test_file|
             ruby "#{args} #{test_file}"
+          end
+        end
+
+        desc 'Run only tests related to changes in TARGET_SHA (defaults to HEAD) against BASE_SHA (defaults to merge base against master)'
+        task 'test' do
+          repo = Rugged::Repository.discover('.')
+          target_sha = ENV['TARGET_SHA'] || repo.head.target_id
+          base_sha = ENV['BASE_SHA'] || repo.merge_base(target_sha, repo.rev_parse('master'))
+          ts = TTNT::TestSelector.new(target_sha, base_sha)
+          tests = ts.select_tests
+          if tests.empty?
+            STDERR.puts 'No test selected.'
+          else
+            # TODO: actually run tests
+            puts tests
           end
         end
       end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -1,0 +1,35 @@
+module TTNT
+  class TestTask
+    @@instances = []
+
+    def self.instances
+      @@instances
+    end
+
+    ATTRIBUTES = %i(
+      name
+      libs
+      pattern
+      options
+      test_files
+      warning
+      loader
+      ruby_opts
+      description
+      pattern
+    ).freeze
+
+    ATTRIBUTES.each do |attr|
+      attr_reader attr
+    end
+
+    def initialize(rake_test_task)
+      ATTRIBUTES.each do |attr|
+        if rake_test_task.respond_to?(attr)
+          instance_eval("@#{attr.to_s} = rake_test_task.#{attr.to_s}")
+        end
+      end
+      @@instances << self
+    end
+  end
+end


### PR DESCRIPTION
Implemented rake tasks. This introduces `rake ttnt:anchor` and `rake ttnt:test` tasks when being set up.
See changes in README for setting up this feature.

Related: #5 