### PR TITLE
Store mapping into single file

### DIFF
--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -11,4 +11,5 @@ at_exit do
   sha = Rugged::Repository.discover('.').head.target_id
   mapping = TTNT::TestToCodeMapping.new(sha)
   mapping.append_from_coverage(test_file, Coverage.result)
+  mapping.save_commit_info(sha)
 end

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -41,6 +41,11 @@ module TTNT
       tests
     end
 
+    # FIXME: this might not be the responsibility for this class
+    def save_commit_info(sha)
+      File.write(commit_info_file, sha)
+    end
+
     private
 
     def normalized_path(file)
@@ -85,6 +90,10 @@ module TTNT
 
     def mapping_file
       "#{base_savedir}/test_to_code_mapping.json"
+    end
+
+    def commit_info_file
+      "#{base_savedir}/commit_obj.txt"
     end
   end
 end

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -3,11 +3,10 @@ require 'json'
 
 # Terminologies:
 #   spectra: { filename => [line, numbers, executed], ... }
+#   mapping: { test_file => spectra }
 
 module TTNT
   class TestToCodeMapping
-    DIRECTORY_SEPARATOR_PLACEHOLDER = '=+='.freeze
-
     def initialize(sha)
       @sha = sha
       @repo = Rugged::Repository.discover('.')
@@ -15,22 +14,23 @@ module TTNT
     end
 
     def append_from_coverage(test, coverage)
-      spectra =  normalize_path(select_project_files(spectra_from_coverage(coverage)))
-      save_spectra(test: test, spectra: spectra)
+      spectra = normalize_path(select_project_files(spectra_from_coverage(coverage)))
+      save_mapping(test: test, spectra: spectra)
     end
 
-    def read_spectra(test:)
-      if File.exists?(spectra_file(test: test))
-        JSON.parse(File.read(spectra_file(test: test)))
+    def read_mapping
+      if File.exists?(mapping_file)
+        JSON.parse(File.read(mapping_file))
       else
         {}
       end
     end
 
+    # Get tests affected from change of file `file` at line number `lineno`
     def get_tests(file:, lineno:)
       tests = Set.new
-      all_tests.each do |test|
-        spectra = read_spectra(test: test)
+      mapping = read_mapping
+      mapping.each do |test, spectra|
         lines = spectra[file]
         next unless lines
         n = lines.bsearch { |x| x >= lineno }
@@ -70,30 +70,21 @@ module TTNT
       spectra
     end
 
-    def save_spectra(test:, spectra:)
+    def save_mapping(test:, spectra:)
       dir = base_savedir
       unless File.directory?(dir)
         FileUtils.mkdir_p(dir)
       end
-      File.write(spectra_file(test: test), spectra.to_json)
+      mapping = read_mapping.merge({ test => spectra })
+      File.write(mapping_file, mapping.to_json)
     end
 
     def base_savedir
-      "#{@repo.workdir}/.ttnt/#{@sha}/test_to_code_mapping"
+      "#{@repo.workdir}/.ttnt"
     end
 
-    def spectra_file(test:)
-      filename = normalized_path(test).gsub('/', DIRECTORY_SEPARATOR_PLACEHOLDER)
-      "#{base_savedir}/#{filename}.json"
-    end
-
-    def all_tests
-      Dir["#{base_savedir}/*.json"].map do |filename|
-        filename
-          .sub(/.*\//, '')
-          .sub(/\.json\Z/, '')
-          .gsub(DIRECTORY_SEPARATOR_PLACEHOLDER, '/')
-      end
+    def mapping_file
+      "#{base_savedir}/test_to_code_mapping.json"
     end
   end
 end


### PR DESCRIPTION
This PR makes TTNT store test-to-code mapping into single file.

Also, for future use, I made it store the commit object on which `rake ttnt:anchor` is used.