### PR TITLE
Determine base commit properly

### DIFF
--- a/lib/ttnt/tasks.rb
+++ b/lib/ttnt/tasks.rb
@@ -43,7 +43,9 @@ module TTNT
             STDERR.puts 'No test selected.'
           else
             # TODO: actually run tests
-            puts tests
+            tests.each do |test|
+              puts test
+            end
           end
         end
       end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -7,6 +7,11 @@ module TTNT
     def initialize(target_sha, base_sha)
       @repo = Rugged::Repository.discover('.')
       @target_obj = @repo.lookup(target_sha)
+
+      # Base should be the commit `ttnt:anchor` has run on.
+      # NOT the one test-to-code mapping was commited to.
+      ttnt_tree = @repo.lookup(@repo.lookup(base_sha).tree['.ttnt'][:oid])
+      base_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content
       @base_obj = @repo.lookup(base_sha)
     end
 


### PR DESCRIPTION
I noticed that if we make users version control test-to-code mapping, base commit should be defined in a little tricky way. We want base commit to be the commit that `rake ttnt:anchor` is used for. The SHA of such commit is stored by changes in #7, and this PR uses it to select base commit properly.