### PR TITLE
Write integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ before_install: gem install bundler -v 1.10.2
 install:
   - ./bin/setup
 script:
+  - git config --global user.name "Travis User"
+  - git config --global user.email "travisuser@example.com"
   - bundle exec rake test

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+require 'ttnt/test_to_code_mapping'
+
+class IntegrationTest < TTNT::TestCase
+  FIZZBUZZ_FIXTURE_DIR = File.expand_path('../fixtures/repositories/fizzbuzz', __FILE__).freeze
+
+  def setup
+    bundle_install
+  end
+
+  def test_mapping_generation
+    generate_test_to_code_mapping
+    Dir.chdir(@repodir) do
+      commit_info = File.read('.ttnt/commit_obj.txt')
+      assert_equal commit_info, @repo.head.target_id
+      mapping = JSON.parse(File.read('.ttnt/test_to_code_mapping.json'))
+      expected_mapping = {"test/buzz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 6, 7]},
+                          "test/fizz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 5]},
+                          "test/fizzbuzz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 3]},
+                          "test/non_fizzbuzz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 6, 9]}}
+      assert_equal expected_mapping, mapping
+    end
+  end
+
+  def test_test_selection
+    generate_test_to_code_mapping
+    commit_ttnt_files
+    Dir.chdir(@repodir) do
+      system('git checkout -b make_fizz_wrong > /dev/null 2> /dev/null')
+      # Make fizz wrong
+      File.write('lib/fizzbuzz.rb',
+                 File.read('lib/fizzbuzz.rb').sub('"fizz"', '"wrong"'))
+      system('git commit -am "Make fizz wrong" > /dev/null 2> /dev/null')
+      rake_run_output = `bundle exec rake test 2> /dev/null`
+      ttnt_run_output = `bundle exec rake ttnt:test:run 2> /dev/null`
+      assert_match(/4 runs, 10 assertions, 1 failures/, rake_run_output)
+      # Now `rake ttnt:test:run` just lists selected tests and does not run tests
+      # assert_match(/1 runs, 1 assertions, 1 failures/, ttnt_run_output)
+      assert_equal ttnt_run_output.split("\n").count, 1,
+        "Only test/fizz_test.rb should be selected." \
+        " Selected tests: #{ttnt_run_output.split("\n").join(', ')}"
+    end
+  end
+
+  private
+
+  def bundle_install
+    ttnt_root = File.expand_path('../..', __FILE__)
+    Dir.chdir(@repodir) do
+      File.open('Gemfile', 'a') do |f|
+        f.puts "gem 'ttnt', path: '#{ttnt_root}'"
+      end
+      system('bundle install > /dev/null')
+    end
+  end
+
+  def generate_test_to_code_mapping
+    Dir.chdir(@repodir) do
+      system('bundle exec rake ttnt:test:anchor > /dev/null 2> /dev/null')
+    end
+  end
+
+  def commit_ttnt_files
+    Dir.chdir(@repodir) do
+      # FIXME: Use rugged
+      system('git add .ttnt > /dev/null 2> /dev/null')
+      system('git commit -m "Add ttnt files" > /dev/null 2> /dev/null')
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ module TTNT
       @repodir = "#{@tmpdir}/fizzbuzz"
       Dir.chdir(@repodir) do
         FileUtils.rm('.git')
-        File.rename('.gitted', '.git') if File.exist?(".gitted")
+        FileUtils.cp_r('.gitted', '.git') if File.exist?(".gitted")
       end
       @repo = Rugged::Repository.new(@repodir)
     end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -12,7 +12,7 @@ class TestSelectorTest < TTNT::TestCase
   def test_base_obj_selection
     # Commit on which `rake ttnt:anchor` is invoked. Not the one `.ttnt` files are committed
     assert_equal @selector.instance_variable_get('@base_obj').oid,
-      "7683a5d271c6829567d347b927dcf0625f3ce8f5"
+      "bf1931131cf0d01c1a02b8f08085b90c9a92acd4"
   end
 
   def test_selects_tests


### PR DESCRIPTION
I have written integration tests since unit tests cannot cover the logic run inside rake tasks like defined in `task :run do ... end`.

I took an approach to use another git repository ([Genki-S/ttnt_fixture_fizzbuzz](https://github.com/Genki-S/ttnt_fixture_fizzbuzz)). I'm using it in the integration test like this:

1. (Before all tests) Clone the fixture.
2. (Before each test) Copy the fixture in temporary directory, copy `.gitted` (which is generated by  `cp -R .git .gitted` and committed in the fixture repository) to reproduce the git environment of the fixture.
3. Actually run `bundle install`, `rake ttnt:test:anchor`, make changes to application code and check if `rake ttnt:test:run` selects test files related to those changes.

This made the test run slow (this integration tests has 2 test cases and it takes 2 to 3 seconds each on my machine), but I could not come up with better ways :disappointed: Actually I looked a little into rugged to see how they tests, and found they are using fixtures too ([here](https://github.com/libgit2/rugged/blob/master/test/test_helper.rb#L10) and [here](https://github.com/libgit2/libgit2/tree/master/tests/resources)), so this might be the only way to go.

It's using a lot of `system()` and not quite clean, but it's useful (even if in the short run) since there were many times I noticed I broke something when I ran `rake ttnt:test:{anchor,run}` from the command line even though all tests were passing :cry: 

@robin850 could you review the code please?
