### PR TITLE
Refactoring and YARD documenting

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+--protected
+--private
+--list-undoc
+--readme README.md

--- a/lib/ttnt.rb
+++ b/lib/ttnt.rb
@@ -1,5 +1,8 @@
 require "ttnt/version"
 
+# Test This, Not That!
+#
+# See {file:README.md} for more detail.
 module TTNT
   # Your code goes here...
 end

--- a/lib/ttnt.rb
+++ b/lib/ttnt.rb
@@ -2,7 +2,7 @@ require "ttnt/version"
 
 # Test This, Not That!
 #
-# See {file:README.md} for more detail.
+# See {file:README.md} for more details.
 module TTNT
   # Your code goes here...
 end

--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -10,7 +10,7 @@ at_exit do
   # Use current HEAD
   repo = Rugged::Repository.discover('.')
   sha = repo.head.target_id
-  mapping = TTNT::TestToCodeMapping.new(repo, sha)
+  mapping = TTNT::TestToCodeMapping.new(repo)
   mapping.append_from_coverage(test_file, Coverage.result)
   mapping.save_commit_info(sha)
 end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -3,7 +3,11 @@ require 'rugged'
 require_relative './test_to_code_mapping'
 
 module TTNT
+  # Select tests using git information and {TestToCodeMapping}
   class TestSelector
+    # @param repo [Rugged::Reposiotry] repository of the project
+    # @param target_sha [String] sha of the target object
+    # @param base_sha [String] sha of the base object
     def initialize(repo, target_sha, base_sha)
       @repo = repo
       @target_obj = @repo.lookup(target_sha)
@@ -13,6 +17,10 @@ module TTNT
       @base_obj = find_anchored_commit(base_sha)
     end
 
+    # Select tests using differences in base_sha...target_sha and the latest
+    # TestToCodeMapping committed to base_sha
+    #
+    # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
     def select_tests
       tests = Set.new
       mapping = TTNT::TestToCodeMapping.new(@repo, @base_obj.oid)
@@ -42,6 +50,9 @@ module TTNT
 
     private
 
+    # Find the commit `rake ttnt:test:anchor` has been run on.
+    #
+    # @param sha [String] sha of a commit from which search starts
     def find_anchored_commit(sha)
       ttnt_tree = @repo.lookup(@repo.lookup(sha).tree['.ttnt'][:oid])
       anchored_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -18,7 +18,7 @@ module TTNT
     end
 
     # Select tests using differences in base_sha...target_sha and the latest
-    # TestToCodeMapping committed to base_sha
+    # TestToCodeMapping committed to base_sha.
     #
     # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
     def select_tests

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -23,7 +23,7 @@ module TTNT
     # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
     def select_tests
       tests = Set.new
-      mapping = TTNT::TestToCodeMapping.new(@repo, @base_obj.oid)
+      mapping = TTNT::TestToCodeMapping.new(@repo)
       # TODO: if mapping is not found (ttnt-anchor has not been run)
 
       diff = @base_obj.diff(@target_obj)

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -10,9 +10,7 @@ module TTNT
 
       # Base should be the commit `ttnt:anchor` has run on.
       # NOT the one test-to-code mapping was commited to.
-      ttnt_tree = @repo.lookup(@repo.lookup(base_sha).tree['.ttnt'][:oid])
-      base_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content
-      @base_obj = @repo.lookup(base_sha)
+      @base_obj = find_anchored_commit(base_sha)
     end
 
     def select_tests
@@ -40,6 +38,14 @@ module TTNT
         end
       end
       tests.delete(nil)
+    end
+
+    private
+
+    def find_anchored_commit(sha)
+      ttnt_tree = @repo.lookup(@repo.lookup(sha).tree['.ttnt'][:oid])
+      anchored_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content
+      @repo.lookup(anchored_sha)
     end
   end
 end

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -15,7 +15,7 @@ module TTNT
 
     def append_from_coverage(test, coverage)
       spectra = normalize_path(select_project_files(spectra_from_coverage(coverage)))
-      save_mapping(test: test, spectra: spectra)
+      update_mapping_entry(test: test, spectra: spectra)
     end
 
     def read_mapping
@@ -77,7 +77,7 @@ module TTNT
       spectra
     end
 
-    def save_mapping(test:, spectra:)
+    def update_mapping_entry(test:, spectra:)
       dir = base_savedir
       unless File.directory?(dir)
         FileUtils.mkdir_p(dir)

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -2,22 +2,33 @@ require 'rugged'
 require 'json'
 require 'set'
 
-# Terminologies:
-#   spectra: { filename => [line, numbers, executed], ... }
-#   mapping: { test_file => spectra }
-
 module TTNT
+  # Mapping from test file to executed code (i.e. coverage without execution count)
+  #
+  # Terminologies:
+  #   spectra: { filename => [line, numbers, executed], ... }
+  #   mapping: { test_file => spectra }
   class TestToCodeMapping
+    # @param repo [Rugged::Reposiotry] repository to save test-to-code mapping
+    #   (only repo.workdir is used to determine where to save the mapping file)
     def initialize(repo)
       @repo = repo
       raise 'Not in a git repository' unless @repo
     end
 
+    # Append the new mapping to test-to-code mapping file.
+    #
+    # @param test [String] test file to which the coverage data is produced
+    # @param coverage [Hash] coverage data generated using `Coverage.start` and `Coverage.result`
+    # @return [void]
     def append_from_coverage(test, coverage)
       spectra = normalize_path(select_project_files(spectra_from_coverage(coverage)))
       update_mapping_entry(test: test, spectra: spectra)
     end
 
+    # Read test-to-code mapping from file
+    #
+    # @return [Hash] test-to-code mapping
     def read_mapping
       if File.exists?(mapping_file)
         JSON.parse(File.read(mapping_file))
@@ -27,6 +38,10 @@ module TTNT
     end
 
     # Get tests affected from change of file `file` at line number `lineno`
+    #
+    # @param file [String] file name which might have effects on some tests
+    # @param lineno [Integer] line number in the file which might have effects on some tests
+    # @return [Set] a set of test files which might be affected by the change in file at lineno
     def get_tests(file:, lineno:)
       tests = Set.new
       read_mapping.each do |test, spectra|
@@ -40,6 +55,10 @@ module TTNT
       tests
     end
 
+    # Save sha as the commit object anchoring has been run on
+    #
+    # @param sha [String] sha of the commit anchoring has been run on
+    # @return [void]
     # FIXME: this might not be the responsibility for this class
     def save_commit_info(sha)
       unless File.directory?(File.dirname(commit_info_file))
@@ -50,22 +69,38 @@ module TTNT
 
     private
 
+    # Convert absolute path to relative path from the project (git repository) root.
+    #
+    # @param file [String] file name (absolute path)
+    # @return [String] normalized file path
     def normalized_path(file)
       File.expand_path(file).sub(@repo.workdir, '')
     end
 
+    # Normalize all file names in a spectra.
+    #
+    # @param spectra [Hash] spectra data
+    # @return [Hash] spectra whose keys (file names) are normalized
     def normalize_path(spectra)
       spectra.map do |filename, lines|
         [normalized_path(filename), lines]
       end.to_h
     end
 
+    # Filter out the files outside of the target project using file path.
+    #
+    # @param spectra [Hash] spectra data
+    # @return [Hash] spectra with only files inside the target project
     def select_project_files(spectra)
       spectra.select do |filename, lines|
         filename.start_with?(@repo.workdir)
       end
     end
 
+    # Generate spectra data from Ruby coverage library's data
+    #
+    # @param cov [Hash] coverage data generated using `Coverage.result`
+    # @return [Hash] spectra data
     def spectra_from_coverage(cov)
       spectra = Hash.new { |h, k| h[k] = [] }
       cov.each do |filename, executions|
@@ -77,6 +112,11 @@ module TTNT
       spectra
     end
 
+    # Update single test-to-code mapping entry in a file
+    #
+    # @param test [String] target test file
+    # @param spectra [Hash] spectra data for when executing the test file
+    # @return [void]
     def update_mapping_entry(test:, spectra:)
       dir = base_savedir
       unless File.directory?(dir)
@@ -86,14 +126,23 @@ module TTNT
       File.write(mapping_file, mapping.to_json)
     end
 
+    # Base directory to save TTNT related files
+    #
+    # @return [String]
     def base_savedir
       "#{@repo.workdir}/.ttnt"
     end
 
+    # File name to save test-to-code mapping
+    #
+    # @return [String]
     def mapping_file
       "#{base_savedir}/test_to_code_mapping.json"
     end
 
+    # File name to save commit object on which anchoring has been run
+    #
+    # @return [String]
     def commit_info_file
       "#{base_savedir}/commit_obj.txt"
     end

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -8,9 +8,8 @@ require 'set'
 
 module TTNT
   class TestToCodeMapping
-    def initialize(repo, sha)
+    def initialize(repo)
       @repo = repo
-      @sha = sha
       raise 'Not in a git repository' unless @repo
     end
 

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -22,7 +22,7 @@ module TTNT
     # @param coverage [Hash] coverage data generated using `Coverage.start` and `Coverage.result`
     # @return [void]
     def append_from_coverage(test, coverage)
-      spectra = normalize_path(select_project_files(spectra_from_coverage(coverage)))
+      spectra = normalize_paths(select_project_files(spectra_from_coverage(coverage)))
       update_mapping_entry(test: test, spectra: spectra)
     end
 
@@ -81,7 +81,7 @@ module TTNT
     #
     # @param spectra [Hash] spectra data
     # @return [Hash] spectra whose keys (file names) are normalized
-    def normalize_path(spectra)
+    def normalize_paths(spectra)
       spectra.map do |filename, lines|
         [normalized_path(filename), lines]
       end.to_h

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -3,7 +3,7 @@ require 'json'
 require 'set'
 
 module TTNT
-  # Mapping from test file to executed code (i.e. coverage without execution count)
+  # Mapping from test file to executed code (i.e. coverage without execution count).
   #
   # Terminologies:
   #   spectra: { filename => [line, numbers, executed], ... }
@@ -18,7 +18,7 @@ module TTNT
 
     # Append the new mapping to test-to-code mapping file.
     #
-    # @param test [String] test file to which the coverage data is produced
+    # @param test [String] test file for which the coverage data is produced
     # @param coverage [Hash] coverage data generated using `Coverage.start` and `Coverage.result`
     # @return [void]
     def append_from_coverage(test, coverage)
@@ -55,9 +55,9 @@ module TTNT
       tests
     end
 
-    # Save sha as the commit object anchoring has been run on
+    # Save commit's sha anchoring has been run on.
     #
-    # @param sha [String] sha of the commit anchoring has been run on
+    # @param sha [String] commit's sha anchoring has been run on
     # @return [void]
     # FIXME: this might not be the responsibility for this class
     def save_commit_info(sha)

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -3,9 +3,15 @@ require 'rake'
 require 'ttnt/test_selector'
 
 module TTNT
+  # TTNT version of Rake::TestTask.
+  # Uses configuration from Rake::TestTask to minimize user configuration.
+  # Defines TTNT related rake tasks when instantiated.
   class TestTask
     include Rake::DSL
 
+    # Create an instance of TTNT::TestTask and define TTNT rake tasks.
+    #
+    # @param rake_test_task [Rake::TestTask] an instance of Rake::TestTask after user configuration is done
     def initialize(rake_test_task)
       attributes = rake_test_task.instance_variables
       attributes.map! { |attribute| attribute[1..-1] }
@@ -24,13 +30,19 @@ module TTNT
       define_tasks
     end
 
+    # Git repository discovered from current directory
+    #
+    # @return [Rugged::Reposiotry]
     def repo
       @repo ||= Rugged::Repository.discover('.')
     end
 
-    # Task definitions are taken from Rake::TestTask
-    # https://github.com/ruby/rake/blob/e644af3/lib/rake/testtask.rb#L98-L112
+    # Define TTNT tasks under namespace 'ttnt:TESTNAME'
+    #
+    # @return [void]
     def define_tasks
+      # Task definitions are taken from Rake::TestTask
+      # https://github.com/ruby/rake/blob/e644af3/lib/rake/testtask.rb#L98-L112
       namespace :ttnt do
         namespace @name do
           define_run_task
@@ -39,6 +51,13 @@ module TTNT
       end
     end
 
+    # Define a task which runs only tests which might have affected from changes
+    # in BASE_SHA...TARGET_SHA
+    #
+    # TARGET_SHA and BASE_SHA can be specified as an environment variable. They
+    # defaults to HEAD and merge base between master and TARGET_SHA, respectively.
+    #
+    # @return [void]
     def define_run_task
       desc @run_description
       task 'run' do
@@ -57,6 +76,10 @@ module TTNT
       end
     end
 
+    # Define a task which runs test files file by file, and generate and save
+    # test-to-code mapping.
+    #
+    # @return [void]
     def define_anchor_task
       desc @anchor_description
       task 'anchor' do

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -30,6 +30,8 @@ module TTNT
       define_tasks
     end
 
+    private
+
     # Git repository discovered from current directory
     #
     # @return [Rugged::Reposiotry]

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -24,6 +24,10 @@ module TTNT
       define_tasks
     end
 
+    def repo
+      @repo ||= Rugged::Repository.discover('.')
+    end
+
     # Task definitions are taken from Rake::TestTask
     # https://github.com/ruby/rake/blob/e644af3/lib/rake/testtask.rb#L98-L112
     def define_tasks
@@ -38,7 +42,6 @@ module TTNT
     def define_run_task
       desc @run_description
       task 'run' do
-        repo = Rugged::Repository.discover('.')
         target_sha = ENV['TARGET_SHA'] || repo.head.target_id
         base_sha = ENV['BASE_SHA'] || repo.merge_base(target_sha, repo.rev_parse('master'))
         ts = TTNT::TestSelector.new(repo, target_sha, base_sha)

--- a/lib/ttnt/version.rb
+++ b/lib/ttnt/version.rb
@@ -1,4 +1,3 @@
 module TTNT
-  # TTNT version
   VERSION = "0.0.2"
 end

--- a/lib/ttnt/version.rb
+++ b/lib/ttnt/version.rb
@@ -1,3 +1,4 @@
 module TTNT
+  # TTNT version
   VERSION = "0.0.2"
 end

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -5,7 +5,7 @@ class TestToCodeMappingTest < TTNT::TestCase
   def setup
     # These tests do not depend on fixture file
     File.delete("#{@repo.workdir}/.ttnt/test_to_code_mapping.json")
-    @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo, @repo.head.target_id)
+    @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo)
   end
 
   def test_append_from_coverage

--- a/ttnt.gemspec
+++ b/ttnt.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "yard"
 
   # Pry
   spec.add_development_dependency "hirb"


### PR DESCRIPTION
I determined to make code a little easier to understand, so I did some refactoring and wrote documentation with YARD.

@robin850 could you review the code please?

While doing this, I realized I made a bug, that is `TTNT::TestToCodeMapping#read_mapping` should read test-to-code mapping from the git tree of base object (i.e. mapping file saved before). Currently, it's reading test-to-code mapping from mapping file in current working tree. I will address this bug in different pull request. (issue: #16)