### PR TITLE
Run selected tests using an instance of `Rake::TestTask`

### DIFF
--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -65,10 +65,10 @@ module TTNT
         if tests.empty?
           STDERR.puts 'No test selected.'
         else
-          # TODO: actually run tests
-          tests.each do |test|
-            puts test
-          end
+          args =
+            "#{@rake_testtask.ruby_opts_string} #{@rake_testtask.run_code} " +
+            "#{tests.to_a.join(' ')} #{@rake_testtask.option_list}"
+          run_ruby args
         end
       end
     end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -83,10 +83,9 @@ module TTNT
         Rake::FileUtilsExt.verbose(@rake_testtask.verbose) do
           # Make it possible to require files in this gem
           gem_root = File.expand_path('../..', __FILE__)
-          args = "-I#{gem_root}"
-
-          # TODO: properly regard run options defined for Rake::TestTask
-          args += " -I#{@rake_testtask.libs.join(':')} -r ttnt/anchor"
+          args =
+            "-I#{gem_root} -r ttnt/anchor " +
+            "#{@rake_testtask.ruby_opts_string}"
 
           test_files = Rake::FileList[@rake_testtask.pattern].compact
           test_files += @test_files.to_a if @test_files

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -11,19 +11,19 @@ module TTNT
 
     # Create an instance of TTNT::TestTask and define TTNT rake tasks.
     #
-    # @param rake_test_task [Rake::TestTask] an instance of Rake::TestTask after user configuration is done
-    def initialize(rake_test_task)
-      attributes = rake_test_task.instance_variables
+    # @param rake_testtask [Rake::TestTask] an instance of Rake::TestTask after user configuration is done
+    def initialize(rake_testtask)
+      attributes = rake_testtask.instance_variables
       attributes.map! { |attribute| attribute[1..-1] }
 
       attributes.each do |ivar|
         self.class.class_eval("attr_accessor :#{ivar}")
-        if rake_test_task.respond_to?(ivar)
-          send(:"#{ivar}=", rake_test_task.send(:"#{ivar}"))
+        if rake_testtask.respond_to?(ivar)
+          send(:"#{ivar}=", rake_testtask.send(:"#{ivar}"))
         end
       end
       # Since test_files is not exposed in Rake::TestTask
-      @test_files = rake_test_task.instance_variable_get('@test_files')
+      @test_files = rake_testtask.instance_variable_get('@test_files')
 
       @anchor_description = 'Generate test-to-code mapping' + (@name == :test ? '' : " for #{@name}")
       @run_description = 'Run selected tests' + (@name == :test ? '' : "for #{@name}")

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -90,15 +90,22 @@ module TTNT
           test_files = Rake::FileList[@rake_testtask.pattern].compact
           test_files += @test_files.to_a if @test_files
           test_files.each do |test_file|
-            ruby "#{args} #{test_file}" do |ok, status|
-              if !ok && status.respond_to?(:signaled?) && status.signaled?
-                raise SignalException.new(status.termsig)
-              elsif !ok
-                fail "Command failed with status (#{status.exitstatus}): " +
-                  "[ruby #{args}]"
-              end
-            end
+            run_ruby "#{args} #{test_file}"
           end
+        end
+      end
+    end
+
+    # Run ruby process with given args
+    #
+    # @param args [String] argument to pass to ruby
+    def run_ruby(args)
+      ruby "#{args}" do |ok, status|
+        if !ok && status.respond_to?(:signaled?) && status.signaled?
+          raise SignalException.new(status.termsig)
+        elsif !ok
+          fail "Command failed with status (#{status.exitstatus}): " +
+            "[ruby #{args}]"
         end
       end
     end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -22,8 +22,7 @@ class TestTaskTest < Minitest::Test
       "`ttnt:#{@name}:run` task should be defined"
   end
 
-  def test_attributes
-    assert_equal @rake_task.libs, @ttnt_task.libs
-    assert_equal @rake_task.pattern, @ttnt_task.pattern
+  def test_composing_rake_testtask
+    assert_equal @rake_task, @ttnt_task.rake_testtask
   end
 end


### PR DESCRIPTION
As mentioned in #1, I introduced these changes:

- Store the instance of `Rake::TestTask` and use attributes from it (and stop copying instance variables to self): https://github.com/Genki-S/ttnt/commit/c7c2c37d7912042167bd07267a2e4e30c014aa5b
- Run selected tests using methods in `Rake::TestTask`: https://github.com/Genki-S/ttnt/commit/3f232786a4e73c35d459b6a588a58e2bd53facc5

Additionally (since it is somewhat related), I made `ttnt:test:anchor` task regard ruby options specified for `Rake::TestTask` like this: https://github.com/Genki-S/ttnt/commit/ccf67f5089de8b3fb6a4c798ea05f4829ea70d3d

@robin850 could you review the code please?