### PR TITLE
Make it possible for `TTNT::TestSelector` to determine base sha and target sha by itself

### DIFF
--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -12,5 +12,4 @@ at_exit do
   sha = repo.head.target_id
   mapping = TTNT::TestToCodeMapping.new(repo)
   mapping.append_from_coverage(test_file, Coverage.result)
-  mapping.save_commit_info(sha)
 end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -11,10 +11,7 @@ module TTNT
     def initialize(repo, target_sha, base_sha)
       @repo = repo
       @target_obj = @repo.lookup(target_sha)
-
-      # Base should be the commit `ttnt:anchor` has run on.
-      # NOT the one test-to-code mapping was commited to.
-      @base_obj = find_anchored_commit(base_sha)
+      @base_obj = find_anchoring_commit
     end
 
     # Select tests using differences in base_sha...target_sha and the latest
@@ -50,13 +47,34 @@ module TTNT
 
     private
 
-    # Find the commit `rake ttnt:test:anchor` has been run on.
+    # Walk through the history starting from HEAD and find the nearest
+    # anchoring commit. Basically the same as doing
+    # `git log -- .ttnt/test_to_code_mapping.json` and take the first commit.
     #
-    # @param sha [String] sha of a commit from which search starts
-    def find_anchored_commit(sha)
-      ttnt_tree = @repo.lookup(@repo.lookup(sha).tree['.ttnt'][:oid])
-      anchored_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content
-      @repo.lookup(anchored_sha)
+    # @return [Rugged::Commit] the latest commit mapping file is committed
+    def find_anchoring_commit
+      head_oid = lookup_mapping_file(@repo.head.target.tree)[:oid]
+      walker = Rugged::Walker.new(@repo)
+      walker.push(@repo.head.target.oid)
+      prev_commit = nil
+      found = nil
+      walker.each do |commit|
+        obj = lookup_mapping_file(commit.tree)
+        if obj.nil? || obj[:oid] != head_oid
+          found = prev_commit
+          break
+        end
+        prev_commit = commit
+      end
+      found
+    end
+
+    def lookup_mapping_file(tree)
+      begin
+        @repo.lookup(tree['.ttnt'][:oid])['test_to_code_mapping.json']
+      rescue
+        nil
+      end
     end
   end
 end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -6,11 +6,9 @@ module TTNT
   # Select tests using git information and {TestToCodeMapping}
   class TestSelector
     # @param repo [Rugged::Reposiotry] repository of the project
-    # @param target_sha [String] sha of the target object
-    # @param base_sha [String] sha of the base object
-    def initialize(repo, target_sha, base_sha)
+    def initialize(repo)
       @repo = repo
-      @target_obj = @repo.lookup(target_sha)
+      @target_obj = @repo.head.target
       @base_obj = find_anchoring_commit
     end
 

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -18,7 +18,7 @@ module TTNT
     # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
     def select_tests
       tests = Set.new
-      mapping = TTNT::TestToCodeMapping.new(@repo)
+      mapping = TTNT::TestToCodeMapping.new(@repo, @base_obj.oid)
       # TODO: if mapping is not found (ttnt-anchor has not been run)
 
       diff = @base_obj.diff(@target_obj)

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -55,18 +55,6 @@ module TTNT
       tests
     end
 
-    # Save commit's sha anchoring has been run on.
-    #
-    # @param sha [String] commit's sha anchoring has been run on
-    # @return [void]
-    # FIXME: this might not be the responsibility for this class
-    def save_commit_info(sha)
-      unless File.directory?(File.dirname(commit_info_file))
-        FileUtils.mkdir_p(File.dirname(commit_info_file))
-      end
-      File.write(commit_info_file, sha)
-    end
-
     private
 
     # Convert absolute path to relative path from the project (git repository) root.
@@ -138,13 +126,6 @@ module TTNT
     # @return [String]
     def mapping_file
       "#{base_savedir}/test_to_code_mapping.json"
-    end
-
-    # File name to save commit object on which anchoring has been run
-    #
-    # @return [String]
-    def commit_info_file
-      "#{base_savedir}/commit_obj.txt"
     end
   end
 end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -1,4 +1,5 @@
 require 'rugged'
+require 'colorize'
 require 'rake'
 require 'ttnt/test_selector'
 
@@ -85,6 +86,11 @@ module TTNT
         # See test/test_helper.rb
         ENV['ANCHOR_TASK'] = '1'
 
+        unless repo.diff_workdir('HEAD').deltas.empty?
+          print_dirty_workdir_warning
+          exit 1
+        end
+
         Rake::FileUtilsExt.verbose(@rake_testtask.verbose) do
           # Make it possible to require files in this gem
           gem_root = File.expand_path('../..', __FILE__)
@@ -113,6 +119,15 @@ module TTNT
             "[ruby #{args}]"
         end
       end
+    end
+
+    def print_dirty_workdir_warning
+      lines = [
+        'You have uncommited changes in your working directory.',
+        'This can produce inconsistent data to your test-to-code mapping.',
+        "Please commit changes before running `rake ttnt:#{@rake_testtask.name}:anchor`."
+      ].map { |l| l.colorize(:red) }
+      warn(*lines)
     end
   end
 end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -62,9 +62,7 @@ module TTNT
     def define_run_task
       desc @run_description
       task 'run' do
-        target_sha = ENV['TARGET_SHA'] || repo.head.target_id
-        base_sha = ENV['BASE_SHA'] || repo.merge_base(target_sha, repo.rev_parse('master'))
-        ts = TTNT::TestSelector.new(repo, target_sha, base_sha)
+        ts = TTNT::TestSelector.new(repo)
         tests = ts.select_tests
         if tests.empty?
           STDERR.puts 'No test selected.'

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -3,16 +3,14 @@ require 'ttnt/test_selector'
 
 class TestSelectorTest < TTNT::TestCase
   def setup
-    target_sha = @repo.branches['change_fizz'].target.oid
-    master_sha = @repo.branches['master'].target.oid
-    base_sha = @repo.merge_base(target_sha, master_sha)
-    @selector = TTNT::TestSelector.new(@repo, target_sha, base_sha)
+    @repo.checkout('change_fizz')
+    @selector = TTNT::TestSelector.new(@repo)
   end
 
   def test_base_obj_selection
-    # Commit on which `rake ttnt:anchor` is invoked. Not the one `.ttnt` files are committed
+    # Commit on which mapping file is committed
     assert_equal @selector.instance_variable_get('@base_obj').oid,
-      "7683a5d271c6829567d347b927dcf0625f3ce8f5"
+      "0de92248f0a16e27d7b017ff61428163bb136cbc"
   end
 
   def test_selects_tests

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -19,11 +19,6 @@ class TestToCodeMappingTest < TTNT::TestCase
     assert_equal expected_mapping, @test_to_code_mapping.read_mapping
   end
 
-  def test_save_commit_info
-    @test_to_code_mapping.save_commit_info(@repo.head.target_id)
-    assert_equal @repo.head.target_id, File.read("#{@repo.workdir}/.ttnt/commit_obj.txt")
-  end
-
   def test_get_tests
     test_file = 'test/fizz_test.rb'
     coverage = { "#{@repo.workdir}/lib/fizzbuzz.rb"=> [1, 1, nil, 1, 0, 1, 0, 1] }

--- a/ttnt.gemspec
+++ b/ttnt.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rugged", "0.23.0b2"
   spec.add_dependency "json", "1.8.3"
+  spec.add_dependency "colorize", "0.7.7"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
@robin850 could you review the idea and the code?
( :warning: I am not confident if my explanation is clear enough :sweat: So, if I'm not clear enough please tell me which point I should clarify more :pray: )

I introduced some rules in order to make the problem of finding base commit (to which diff should be calculated) much simpler. Currently I'm taking the approach to store the sha of the commit into a file ('.ttnt/commit_obj.txt'), but it's not elegant I think. Here are the rules:

- When `rake ttnt:test:anchor` is run and succeeded, test-to-code mapping file is committed automatically ( https://github.com/Genki-S/ttnt/commit/546861c3e8d82693f5d4ee9b7cbf29ac2c487e95 )
  - this makes "anchored commit" (the commit on which coverage information is recorded) and "anchoring commit" (the commit test-to-code mapping file is saved) atomic
- When `rake ttnt:test:anchor` is run, the working tree should be clean ( https://github.com/Genki-S/ttnt/commit/fb77e0cfb8ac53062856d7a1b349694efdb52eec )
  - this assures that anchoring commit does not include coverage information which cannot be reproduced on anchored commit

By these rules, when a user runs `rake ttnt:test:run`, we only have to do following steps to calculate which tests to run:

1. Regard 'HEAD' as the target commit. ( https://github.com/Genki-S/ttnt/commit/9540c95c8bf1d6b3d8cc51375bb37ec7794f3c30 )
1. Find the latest commit test-to-code mapping is saved. Regard this as the base commit. ( https://github.com/Genki-S/ttnt/commit/0427829a92fdfede972e7d30baceeddfbfb56430 )
1. Read the test-to-code mapping from the base commit ( https://github.com/Genki-S/ttnt/commit/9df58f9de65533232fa78850ab24c9d22f8c69cf )
1. Calculate the tests to run based on the test-to-code mapping and the diff between base commit and target commit ( this is the same as before and not changed in this PR )
1. Run selected tests ( this is not changed as well )

This makes it unneccessary to store the sha of commit `rake ttnt:test:anchor` has been run on. So I removed it (https://github.com/Genki-S/ttnt/commit/01dd0b96579d4f27e2687656b8e0cd67213b65b6 ).
