### PR TITLE
Run test file if it is changed or added

### DIFF
--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -5,6 +5,9 @@ require_relative './test_to_code_mapping'
 module TTNT
   # Select tests using git information and {TestToCodeMapping}
   class TestSelector
+
+    attr_reader :tests
+
     # @param repo [Rugged::Reposiotry] repository of the project
     # @param target_sha [String] sha of the target object
     # @param base_sha [String] sha of the base object
@@ -18,26 +21,25 @@ module TTNT
       @base_obj = find_anchored_commit(base_sha)
 
       @test_files = test_files
+      @tests = Set.new
     end
 
     # Select tests using differences in base_sha...target_sha and the latest
     # TestToCodeMapping committed to base_sha.
     #
     # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
-    def select_tests
+    def select_tests!
       # TODO: if test-to-code-mapping is not found (ttnt-anchor has not been run)
-      tests = Set.new
-
       diff = @base_obj.diff(@target_obj)
       diff.each_patch do |patch|
         file = patch.delta.old_file[:path]
         if test_file?(file)
-          tests << file
+          @tests << file
         else
-          tests += select_tests_from_patch(patch)
+          select_tests_from_patch(patch)
         end
       end
-      tests.delete(nil)
+      @tests.delete(nil)
     end
 
     private
@@ -51,7 +53,6 @@ module TTNT
     # @param patch [Rugged::Patch]
     # @return [Set] set of selected tests
     def select_tests_from_patch(patch)
-      tests = Set.new
       file = patch.delta.old_file[:path]
       patch.each_hunk do |hunk|
         # TODO: think if this selection covers all possibilities
@@ -60,13 +61,12 @@ module TTNT
           when :addition
             # FIXME: new_lineno is suspicious
             #        (what if hunk1 adds 100 lines and hunk2 add 1 line?)
-            tests += mapping.get_tests(file: file, lineno: line.new_lineno)
+            @tests += mapping.get_tests(file: file, lineno: line.new_lineno)
           when :deletion
-            tests += mapping.get_tests(file: file, lineno: line.old_lineno)
+            @tests += mapping.get_tests(file: file, lineno: line.old_lineno)
           end
         end
       end
-      tests.delete(nil)
     end
 
     # Find the commit `rake ttnt:test:anchor` has been run on.

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -29,6 +29,8 @@ module TTNT
       diff = @base_obj.diff(@target_obj)
       diff.each_patch do |patch|
         file = patch.delta.old_file[:path]
+        tests << file and next if test_file?(file)
+
         patch.each_hunk do |hunk|
           # TODO: think if this selection covers all possibilities
           hunk.each_line do |line|
@@ -55,6 +57,15 @@ module TTNT
       ttnt_tree = @repo.lookup(@repo.lookup(sha).tree['.ttnt'][:oid])
       anchored_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content
       @repo.lookup(anchored_sha)
+    end
+
+    # Check if given file is a test file
+    #
+    # @param filename [String]
+    def test_file?(filename)
+      # Checking by file name convention.
+      # FIXME: Use Rake::TestTask to truly detect if it's a test file or not
+      filename =~ /^test\/.*\.rb/
     end
   end
 end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -42,7 +42,7 @@ module TTNT
 
     private
 
-    def test_to_code_mapping
+    def mapping
       @mapping ||= TTNT::TestToCodeMapping.new(@repo)
     end
 
@@ -60,9 +60,9 @@ module TTNT
           when :addition
             # FIXME: new_lineno is suspicious
             #        (what if hunk1 adds 100 lines and hunk2 add 1 line?)
-            tests += test_to_code_mapping.get_tests(file: file, lineno: line.new_lineno)
+            tests += mapping.get_tests(file: file, lineno: line.new_lineno)
           when :deletion
-            tests += test_to_code_mapping.get_tests(file: file, lineno: line.old_lineno)
+            tests += mapping.get_tests(file: file, lineno: line.old_lineno)
           end
         end
       end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -21,7 +21,6 @@ module TTNT
       @base_obj = find_anchored_commit(base_sha)
 
       @test_files = test_files
-      @tests = Set.new
     end
 
     # Select tests using differences in base_sha...target_sha and the latest
@@ -30,6 +29,7 @@ module TTNT
     # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
     def select_tests!
       # TODO: if test-to-code-mapping is not found (ttnt-anchor has not been run)
+      @tests ||= Set.new
       diff = @base_obj.diff(@target_obj)
       diff.each_patch do |patch|
         file = patch.delta.old_file[:path]

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -39,8 +39,6 @@ module TTNT
               tests += mapping.get_tests(file: file, lineno: line.new_lineno)
             when :deletion
               tests += mapping.get_tests(file: file, lineno: line.old_lineno)
-            else
-              # do nothing
             end
           end
         end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -8,13 +8,16 @@ module TTNT
     # @param repo [Rugged::Reposiotry] repository of the project
     # @param target_sha [String] sha of the target object
     # @param base_sha [String] sha of the base object
-    def initialize(repo, target_sha, base_sha)
+    # @param test_files [#include?] candidate test files
+    def initialize(repo, target_sha, base_sha, test_files)
       @repo = repo
       @target_obj = @repo.lookup(target_sha)
 
       # Base should be the commit `ttnt:anchor` has run on.
       # NOT the one test-to-code mapping was commited to.
       @base_obj = find_anchored_commit(base_sha)
+
+      @test_files = test_files
     end
 
     # Select tests using differences in base_sha...target_sha and the latest
@@ -63,9 +66,7 @@ module TTNT
     #
     # @param filename [String]
     def test_file?(filename)
-      # Checking by file name convention.
-      # FIXME: Use Rake::TestTask to truly detect if it's a test file or not
-      filename =~ /^test\/.*\.rb/
+      @test_files.include?(filename)
     end
   end
 end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -25,6 +25,14 @@ module TTNT
       define_tasks
     end
 
+    # Returns array of test file names.
+    #   Unlike Rake::TestTask#file_list, patterns are expanded.
+    def expanded_file_list
+      test_files = Rake::FileList[@rake_testtask.pattern].compact
+      test_files += @test_files.to_a if @test_files
+      test_files
+    end
+
     private
 
     # Git repository discovered from current directory
@@ -92,8 +100,7 @@ module TTNT
             "-I#{gem_root} -r ttnt/anchor " +
             "#{@rake_testtask.ruby_opts_string}"
 
-          test_files = Rake::FileList[@rake_testtask.pattern].compact
-          test_files += @test_files.to_a if @test_files
+          test_files = expanded_file_list
           test_files.each do |test_file|
             run_ruby "#{args} #{test_file}"
           end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -100,8 +100,7 @@ module TTNT
             "-I#{gem_root} -r ttnt/anchor " +
             "#{@rake_testtask.ruby_opts_string}"
 
-          test_files = expanded_file_list
-          test_files.each do |test_file|
+          expanded_file_list.each do |test_file|
             run_ruby "#{args} #{test_file}"
           end
         end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -68,7 +68,7 @@ module TTNT
       task 'run' do
         target_sha = ENV['TARGET_SHA'] || repo.head.target_id
         base_sha = ENV['BASE_SHA'] || repo.merge_base(target_sha, repo.rev_parse('master'))
-        ts = TTNT::TestSelector.new(repo, target_sha, base_sha)
+        ts = TTNT::TestSelector.new(repo, target_sha, base_sha, expanded_file_list)
         tests = ts.select_tests
         if tests.empty?
           STDERR.puts 'No test selected.'

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -69,7 +69,7 @@ module TTNT
         target_sha = ENV['TARGET_SHA'] || repo.head.target_id
         base_sha = ENV['BASE_SHA'] || repo.merge_base(target_sha, repo.rev_parse('master'))
         ts = TTNT::TestSelector.new(repo, target_sha, base_sha, expanded_file_list)
-        tests = ts.select_tests
+        tests = ts.select_tests!
         if tests.empty?
           STDERR.puts 'No test selected.'
         else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,9 +21,12 @@ module TTNT
     def before_setup
       super
       prepare_git_repository
+      @pwd = Dir.pwd
+      Dir.chdir(@repo.workdir)
     end
 
     def after_teardown
+      Dir.chdir(@pwd)
       FileUtils.remove_entry_secure(@tmpdir)
       super
     end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -17,7 +17,7 @@ module TTNT
     end
 
     def test_selects_tests
-      assert_equal @selector.tests.to_a, []
+      assert_equal @selector.tests, nil
       assert_equal @selector.select_tests!.to_a, ['test/fizz_test.rb']
       assert_equal @selector.tests.to_a, ['test/fizz_test.rb']
     end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -18,5 +18,17 @@ module TTNT
     def test_selects_tests
       assert_equal @selector.select_tests.to_a, ['test/fizz_test.rb']
     end
+
+    def test_selects_tests_with_changed_test_file
+      buzz_test = "#{@repo.workdir}/test/buzz_test.rb"
+      File.write(buzz_test, File.read(buzz_test) + "\n") # meaningless change
+      git_checkout_b('change_buzz_test') # from master
+      git_commit_am('Change buzz_test')
+      target_sha = @repo.head.target_id
+      master_sha = @repo.branches['master'].target.oid
+      base_sha = @repo.merge_base(target_sha, master_sha)
+      selector = TTNT::TestSelector.new(@repo, target_sha, base_sha)
+      assert_includes selector.select_tests, 'test/buzz_test.rb'
+    end
   end
 end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -17,7 +17,9 @@ module TTNT
     end
 
     def test_selects_tests
-      assert_equal @selector.select_tests.to_a, ['test/fizz_test.rb']
+      assert_equal @selector.tests.to_a, []
+      assert_equal @selector.select_tests!.to_a, ['test/fizz_test.rb']
+      assert_equal @selector.tests.to_a, ['test/fizz_test.rb']
     end
 
     def test_selects_tests_with_changed_test_file
@@ -29,7 +31,7 @@ module TTNT
       master_sha = @repo.branches['master'].target.oid
       base_sha = @repo.merge_base(target_sha, master_sha)
       selector = TTNT::TestSelector.new(@repo, target_sha, base_sha, @test_files)
-      assert_includes selector.select_tests, 'test/buzz_test.rb'
+      assert_includes selector.select_tests!, 'test/buzz_test.rb'
     end
   end
 end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -7,7 +7,8 @@ module TTNT
       target_sha = @repo.branches['change_fizz'].target.oid
       master_sha = @repo.branches['master'].target.oid
       base_sha = @repo.merge_base(target_sha, master_sha)
-      @selector = TTNT::TestSelector.new(@repo, target_sha, base_sha)
+      @test_files = Rake::FileList['test/**/*_test.rb']
+      @selector = TTNT::TestSelector.new(@repo, target_sha, base_sha, @test_files)
     end
 
     def test_base_obj_selection
@@ -27,7 +28,7 @@ module TTNT
       target_sha = @repo.head.target_id
       master_sha = @repo.branches['master'].target.oid
       base_sha = @repo.merge_base(target_sha, master_sha)
-      selector = TTNT::TestSelector.new(@repo, target_sha, base_sha)
+      selector = TTNT::TestSelector.new(@repo, target_sha, base_sha, @test_files)
       assert_includes selector.select_tests, 'test/buzz_test.rb'
     end
   end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -11,6 +11,7 @@ class TestTaskTest < Minitest::Test
       t.name = @name
       t.libs << 'test'
       t.pattern = 'test/**/*_test.rb'
+      t.test_files = FileList['test/dummy_test.rb']
       @ttnt_task = TTNT::TestTask.new(t)
     }
   end
@@ -24,5 +25,13 @@ class TestTaskTest < Minitest::Test
 
   def test_composing_rake_testtask
     assert_equal @rake_task, @ttnt_task.rake_testtask
+  end
+
+  def test_expanded_file_list
+    # It gathers tests from both `pattern` and `test_files` option for Rake::TestTask
+    assert_equal(
+      Rake::FileList['test/**/*_test.rb'] + Rake::FileList['test/dummy_test.rb'],
+      @ttnt_task.expanded_file_list
+    )
   end
 end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -29,9 +29,7 @@ class TestTaskTest < Minitest::Test
 
   def test_expanded_file_list
     # It gathers tests from both `pattern` and `test_files` option for Rake::TestTask
-    assert_equal(
-      Rake::FileList['test/**/*_test.rb'] + Rake::FileList['test/dummy_test.rb'],
-      @ttnt_task.expanded_file_list
-    )
+    test_files = Rake::FileList['test/**/*_test.rb'] + ['test/dummy_test.rb']
+    assert_equal test_files, @ttnt_task.expanded_file_list
   end
 end


### PR DESCRIPTION
Implementation of #23 

This PR makes it possible to select a test file as target if the test file itself is modified since the base (anchored) commit.

This might seem too big change for such a small change. The reason is that I needed to retrieve the instance of `TTNT::TestTask` in order to check if a given file name is a test file or not.

The second commit ( https://github.com/Genki-S/ttnt/commit/e5c1ba8381b07590e92414d43a8d8579b6f0d868 ) implements the check in simplest way, and the last commit ( https://github.com/Genki-S/ttnt/commit/fd6db90645c3eeb41f6c68a8804cf8e1ea837556 ) modifies the check so that it can pick any test file specified in `Rakefile`. All commits in between are the path to make the last change possible.

@robin850 could you review the code please?