### PR TITLE
Avoid creating folder for ttnt files

### DIFF
--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -1,5 +1,6 @@
 require 'coverage'
 require 'ttnt/test_to_code_mapping'
+require 'ttnt/metadata'
 require 'rugged'
 
 test_file = $0
@@ -12,5 +13,7 @@ at_exit do
   sha = repo.head.target_id
   mapping = TTNT::TestToCodeMapping.new(repo)
   mapping.append_from_coverage(test_file, Coverage.result)
-  mapping.save_commit_info(sha)
+  metadata = TTNT::MetaData.new(repo)
+  metadata.set('anchored_commit', sha)
+  metadata.write!
 end

--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -14,6 +14,6 @@ at_exit do
   mapping = TTNT::TestToCodeMapping.new(repo, nil)
   mapping.append_from_coverage(test_file, Coverage.result)
   metadata = TTNT::MetaData.new(repo, nil)
-  metadata.set('anchored_commit', sha)
+  metadata['anchored_commit'] = sha
   metadata.write!
 end

--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -13,7 +13,7 @@ at_exit do
   sha = repo.head.target_id
   mapping = TTNT::TestToCodeMapping.new(repo)
   mapping.append_from_coverage(test_file, Coverage.result)
-  metadata = TTNT::MetaData.new(repo)
+  metadata = TTNT::MetaData.new(repo, nil)
   metadata.set('anchored_commit', sha)
   metadata.write!
 end

--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -11,9 +11,9 @@ at_exit do
   # Use current HEAD
   repo = Rugged::Repository.discover('.')
   sha = repo.head.target_id
-  mapping = TTNT::TestToCodeMapping.new(repo, nil)
+  mapping = TTNT::TestToCodeMapping.new(repo)
   mapping.append_from_coverage(test_file, Coverage.result)
-  metadata = TTNT::MetaData.new(repo, nil)
+  metadata = TTNT::MetaData.new(repo)
   metadata['anchored_commit'] = sha
   metadata.write!
 end

--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -11,7 +11,7 @@ at_exit do
   # Use current HEAD
   repo = Rugged::Repository.discover('.')
   sha = repo.head.target_id
-  mapping = TTNT::TestToCodeMapping.new(repo)
+  mapping = TTNT::TestToCodeMapping.new(repo, nil)
   mapping.append_from_coverage(test_file, Coverage.result)
   metadata = TTNT::MetaData.new(repo, nil)
   metadata.set('anchored_commit', sha)

--- a/lib/ttnt/metadata.rb
+++ b/lib/ttnt/metadata.rb
@@ -4,8 +4,11 @@ module TTNT
   class MetaData
     STORAGE_SECTION = 'meta'
 
-    def initialize(repo)
-      @storage = Storage.new(repo)
+    # @param repo [Rugged::Repository]
+    # @param sha [String] sha of commit from which metadata is read from.
+    #   nil means to read from current working tree. see {Storage} for more.
+    def initialize(repo, sha)
+      @storage = Storage.new(repo, sha)
       read!
     end
 

--- a/lib/ttnt/metadata.rb
+++ b/lib/ttnt/metadata.rb
@@ -12,11 +12,11 @@ module TTNT
       read!
     end
 
-    def get(name)
+    def [](name)
       @data[name]
     end
 
-    def set(name, value)
+    def []=(name, value)
       @data[name] = value
     end
 

--- a/lib/ttnt/metadata.rb
+++ b/lib/ttnt/metadata.rb
@@ -7,7 +7,7 @@ module TTNT
     # @param repo [Rugged::Repository]
     # @param sha [String] sha of commit from which metadata is read from.
     #   nil means to read from current working tree. see {Storage} for more.
-    def initialize(repo, sha)
+    def initialize(repo, sha = nil)
       @storage = Storage.new(repo, sha)
       read!
     end

--- a/lib/ttnt/metadata.rb
+++ b/lib/ttnt/metadata.rb
@@ -1,0 +1,28 @@
+require 'ttnt/storage'
+
+module TTNT
+  class MetaData
+    STORAGE_SECTION = 'meta'
+
+    def initialize(repo)
+      @storage = Storage.new(repo)
+      read!
+    end
+
+    def get(name)
+      @data[name]
+    end
+
+    def set(name, value)
+      @data[name] = value
+    end
+
+    def read!
+      @data = @storage.read(STORAGE_SECTION)
+    end
+
+    def write!
+      @storage.write!(STORAGE_SECTION, @data)
+    end
+  end
+end

--- a/lib/ttnt/storage.rb
+++ b/lib/ttnt/storage.rb
@@ -37,7 +37,7 @@ module TTNT
       File.open(filename, File::RDWR|File::CREAT, 0644) do |f|
         f.flock(File::LOCK_EX)
         str = f.read
-        data = if str.length > 0 then JSON.parse(str) else {} end
+        data = str.length > 0 ? JSON.parse(str) : {}
         data[section] = value
         f.rewind
         f.write(data.to_json)
@@ -56,11 +56,7 @@ module TTNT
       if @sha
         @repo.lookup(@repo.lookup(@sha).tree['.ttnt'][:oid]).content
       else
-        if File.exist?(filename)
-          File.read(filename)
-        else
-          ""
-        end
+        File.exist?(filename) ? File.read(filename) : ''
       end
     end
   end

--- a/lib/ttnt/storage.rb
+++ b/lib/ttnt/storage.rb
@@ -1,0 +1,44 @@
+module TTNT
+  # A storage to store TTNT data such as test-to-code mapping and metadata.
+  class Storage
+    def initialize(repo)
+      @repo = repo
+    end
+
+    # Read data in section from the storage.
+    #
+    # @param section [String]
+    # @return [Hash]
+    def read(section)
+      if File.size?(filename)
+        JSON.parse(File.read(filename))[section] || {}
+      else
+        {}
+      end
+    end
+
+    # Write value to section in the storage.
+    # Locks the file so that concurrent write does not occur.
+    #
+    # @param section [String]
+    # @param value [Hash]
+    def write!(section, value)
+      File.open(filename, File::RDWR|File::CREAT, 0644) do |f|
+        f.flock(File::LOCK_EX)
+        str = f.read
+        data = if str.length > 0 then JSON.parse(str) else {} end
+        data[section] = value
+        f.rewind
+        f.write(data.to_json)
+        f.flush
+        f.truncate(f.pos)
+      end
+    end
+
+    private
+
+    def filename
+      "#{@repo.workdir}/.ttnt"
+    end
+  end
+end

--- a/lib/ttnt/storage.rb
+++ b/lib/ttnt/storage.rb
@@ -1,5 +1,5 @@
 module TTNT
-  # A storage to store TTNT data such as test-to-code mapping and metadata.
+  # A utility class to store TTNT data such as test-to-code mapping and metadata.
   class Storage
     # Initialize the storage from given repo and sha. This reads contents from
     # a file `.ttnt`. When sha is not nil, contents of the file on that commit

--- a/lib/ttnt/storage.rb
+++ b/lib/ttnt/storage.rb
@@ -1,8 +1,17 @@
 module TTNT
   # A storage to store TTNT data such as test-to-code mapping and metadata.
   class Storage
-    def initialize(repo)
+    # Initialize the storage from given repo and sha. This reads contents from
+    # a file `.ttnt`. When sha is not nil, contents of the file on that commit
+    # is read. Data can be written only when sha is nil (written to current
+    # working tree).
+    #
+    # @param repo [Rugged::Repository]
+    # @param sha [String] sha of the commit from which data should be read
+    #   nil means reading from/writing to current working tree.
+    def initialize(repo, sha = nil)
       @repo = repo
+      @sha = sha
     end
 
     # Read data in section from the storage.
@@ -10,8 +19,9 @@ module TTNT
     # @param section [String]
     # @return [Hash]
     def read(section)
-      if File.size?(filename)
-        JSON.parse(File.read(filename))[section] || {}
+      str = read_storage_content
+      if str.length > 0
+        JSON.parse(str)[section] || {}
       else
         {}
       end
@@ -23,6 +33,7 @@ module TTNT
     # @param section [String]
     # @param value [Hash]
     def write!(section, value)
+      raise 'Data cannot be written to the storage back in git history' unless @sha.nil?
       File.open(filename, File::RDWR|File::CREAT, 0644) do |f|
         f.flock(File::LOCK_EX)
         str = f.read
@@ -39,6 +50,18 @@ module TTNT
 
     def filename
       "#{@repo.workdir}/.ttnt"
+    end
+
+    def read_storage_content
+      if @sha
+        @repo.lookup(@repo.lookup(@sha).tree['.ttnt'][:oid]).content
+      else
+        if File.exist?(filename)
+          File.read(filename)
+        else
+          ""
+        end
+      end
     end
   end
 end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -15,7 +15,7 @@ module TTNT
     # @param test_files [#include?] candidate test files
     def initialize(repo, target_sha, base_sha, test_files)
       @repo = repo
-      @metadata = MetaData.new(repo)
+      @metadata = MetaData.new(repo, target_sha)
       @target_obj = @repo.lookup(target_sha)
 
       # Base should be the commit `ttnt:anchor` has run on.

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -47,7 +47,7 @@ module TTNT
     private
 
     def mapping
-      @mapping ||= TTNT::TestToCodeMapping.new(@repo)
+      @mapping ||= TTNT::TestToCodeMapping.new(@repo, @target_obj.oid)
     end
 
     # Select tests which are affected by the change of given patch.

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -73,7 +73,7 @@ module TTNT
 
     # Find the commit `rake ttnt:test:anchor` has been run on.
     def find_anchored_commit
-      @repo.lookup(@metadata.get('anchored_commit'))
+      @repo.lookup(@metadata['anchored_commit'])
     end
 
     # Check if given file is a test file

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -1,6 +1,7 @@
 require 'set'
 require 'rugged'
-require_relative './test_to_code_mapping'
+require 'ttnt/metadata'
+require 'ttnt/test_to_code_mapping'
 
 module TTNT
   # Select tests using git information and {TestToCodeMapping}
@@ -14,11 +15,12 @@ module TTNT
     # @param test_files [#include?] candidate test files
     def initialize(repo, target_sha, base_sha, test_files)
       @repo = repo
+      @metadata = MetaData.new(repo)
       @target_obj = @repo.lookup(target_sha)
 
       # Base should be the commit `ttnt:anchor` has run on.
       # NOT the one test-to-code mapping was commited to.
-      @base_obj = find_anchored_commit(base_sha)
+      @base_obj = find_anchored_commit
 
       @test_files = test_files
     end
@@ -70,12 +72,8 @@ module TTNT
     end
 
     # Find the commit `rake ttnt:test:anchor` has been run on.
-    #
-    # @param sha [String] sha of a commit from which search starts
-    def find_anchored_commit(sha)
-      ttnt_tree = @repo.lookup(@repo.lookup(sha).tree['.ttnt'][:oid])
-      anchored_sha = @repo.lookup(ttnt_tree['commit_obj.txt'][:oid]).content
-      @repo.lookup(anchored_sha)
+    def find_anchored_commit
+      @repo.lookup(@metadata.get('anchored_commit'))
     end
 
     # Check if given file is a test file

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -14,9 +14,11 @@ module TTNT
 
     # @param repo [Rugged::Reposiotry] repository to save test-to-code mapping
     #   (only repo.workdir is used to determine where to save the mapping file)
-    def initialize(repo)
+    # @param sha [String] sha of commit from which mapping is read from.
+    #   nil means to read from current working tree. see {Storage} for more.
+    def initialize(repo, sha)
       @repo = repo
-      @storage = Storage.new(repo)
+      @storage = Storage.new(repo, sha)
       raise 'Not in a git repository' unless @repo
     end
 

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -14,7 +14,7 @@ module TTNT
 
     # @param repo [Rugged::Reposiotry] repository to save test-to-code mapping
     #   (only repo.workdir is used to determine where to save the mapping file)
-    # @param sha [String] sha of commit from which mapping is read from.
+    # @param sha [String] sha of commit from which mapping is read.
     #   nil means to read from current working tree. see {Storage} for more.
     def initialize(repo, sha)
       @repo = repo

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -16,7 +16,7 @@ module TTNT
     #   (only repo.workdir is used to determine where to save the mapping file)
     # @param sha [String] sha of commit from which mapping is read.
     #   nil means to read from current working tree. see {Storage} for more.
-    def initialize(repo, sha)
+    def initialize(repo, sha = nil)
       @repo = repo
       @storage = Storage.new(repo, sha)
       raise 'Not in a git repository' unless @repo

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -1,3 +1,4 @@
+require 'ttnt/storage'
 require 'rugged'
 require 'json'
 require 'set'
@@ -9,10 +10,13 @@ module TTNT
   #   spectra: { filename => [line, numbers, executed], ... }
   #   mapping: { test_file => spectra }
   class TestToCodeMapping
+    STORAGE_SECTION = 'mapping'
+
     # @param repo [Rugged::Reposiotry] repository to save test-to-code mapping
     #   (only repo.workdir is used to determine where to save the mapping file)
     def initialize(repo)
       @repo = repo
+      @storage = Storage.new(repo)
       raise 'Not in a git repository' unless @repo
     end
 
@@ -26,15 +30,11 @@ module TTNT
       update_mapping_entry(test: test, spectra: spectra)
     end
 
-    # Read test-to-code mapping from file
+    # Read test-to-code mapping from storage.
     #
     # @return [Hash] test-to-code mapping
     def read_mapping
-      if File.exist?(mapping_file)
-        JSON.parse(File.read(mapping_file))
-      else
-        {}
-      end
+      @storage.read(STORAGE_SECTION)
     end
 
     # Get tests affected from change of file `file` at line number `lineno`
@@ -53,18 +53,6 @@ module TTNT
         end
       end
       tests
-    end
-
-    # Save commit's sha anchoring has been run on.
-    #
-    # @param sha [String] commit's sha anchoring has been run on
-    # @return [void]
-    # FIXME: this might not be the responsibility for this class
-    def save_commit_info(sha)
-      unless File.directory?(File.dirname(commit_info_file))
-        FileUtils.mkdir_p(File.dirname(commit_info_file))
-      end
-      File.write(commit_info_file, sha)
     end
 
     private
@@ -112,39 +100,14 @@ module TTNT
       spectra
     end
 
-    # Update single test-to-code mapping entry in a file
+    # Update single test-to-code mapping entry.
     #
     # @param test [String] target test file
     # @param spectra [Hash] spectra data for when executing the test file
     # @return [void]
     def update_mapping_entry(test:, spectra:)
-      dir = base_savedir
-      unless File.directory?(dir)
-        FileUtils.mkdir_p(dir)
-      end
       mapping = read_mapping.merge({ test => spectra })
-      File.write(mapping_file, mapping.to_json)
-    end
-
-    # Base directory to save TTNT related files
-    #
-    # @return [String]
-    def base_savedir
-      "#{@repo.workdir}/.ttnt"
-    end
-
-    # File name to save test-to-code mapping
-    #
-    # @return [String]
-    def mapping_file
-      "#{base_savedir}/test_to_code_mapping.json"
-    end
-
-    # File name to save commit object on which anchoring has been run
-    #
-    # @return [String]
-    def commit_info_file
-      "#{base_savedir}/commit_obj.txt"
+      @storage.write!(STORAGE_SECTION, mapping)
     end
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,7 +6,7 @@ module TTNT
     def test_saving_anchored_commit
       anchored_commit = @repo.head.target_id
       rake('ttnt:test:anchor')
-      metadata = TTNT::MetaData.new(@repo, nil)
+      metadata = TTNT::MetaData.new(@repo)
       assert_equal anchored_commit, metadata['anchored_commit']
     end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,7 +6,7 @@ module TTNT
     def test_saving_anchored_commit
       anchored_commit = @repo.head.target_id
       rake('ttnt:test:anchor')
-      metadata = TTNT::MetaData.new(@repo)
+      metadata = TTNT::MetaData.new(@repo, nil)
       assert_equal anchored_commit, metadata.get('anchored_commit')
     end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -7,7 +7,7 @@ module TTNT
       anchored_commit = @repo.head.target_id
       rake('ttnt:test:anchor')
       metadata = TTNT::MetaData.new(@repo, nil)
-      assert_equal anchored_commit, metadata.get('anchored_commit')
+      assert_equal anchored_commit, metadata['anchored_commit']
     end
 
     def test_mapping_generation

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -4,14 +4,14 @@ require 'ttnt/test_to_code_mapping'
 module TTNT
   class IntegrationTest < TTNT::TestCase
     def test_saving_anchored_commit
-      anchored_sha = @repo.head.target_id
+      anchored_commit = @repo.head.target_id
       rake('ttnt:test:anchor')
-      saved = File.read("#{@repo.workdir}/.ttnt/commit_obj.txt")
-      assert_equal anchored_sha, saved
+      metadata = TTNT::MetaData.new(@repo)
+      assert_equal anchored_commit, metadata.get('anchored_commit')
     end
 
     def test_mapping_generation
-      mapping = JSON.parse(File.read("#{@repo.workdir}/.ttnt/test_to_code_mapping.json"))
+      mapping = TTNT::TestToCodeMapping.new(@repo).read_mapping
       expected_mapping = {"test/buzz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 6, 7]},
                           "test/fizz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 5]}}
       assert_equal expected_mapping, mapping

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -11,7 +11,7 @@ module TTNT
     end
 
     def test_mapping_generation
-      mapping = TTNT::TestToCodeMapping.new(@repo).read_mapping
+      mapping = TTNT::TestToCodeMapping.new(@repo, @repo.head.target_id).read_mapping
       expected_mapping = {"test/buzz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 6, 7]},
                           "test/fizz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 5]}}
       assert_equal expected_mapping, mapping

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -13,13 +13,13 @@ class MetaDataTest < TTNT::TestCase
 
   def test_get_metadata
     File.write(@storage_file, { 'meta' => { @name => @value} }.to_json)
-    assert @metadata.get(@name).nil?, '#get should not read from file.'
+    assert @metadata[@name].nil?, '#get should not read from file.'
     @metadata.read!
-    assert_equal @value, @metadata.get(@name)
+    assert_equal @value, @metadata[@name]
   end
 
   def test_write_metadata
-    @metadata.set(@name, @value)
+    @metadata[@name] = @value
     @metadata.write!
     expected = { 'meta' => { @name => @value } }
     assert_equal expected, JSON.parse(File.read(@storage_file))

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -4,7 +4,7 @@ require 'ttnt/metadata'
 class MetaDataTest < TTNT::TestCase
   def setup
     @storage_file = "#{@repo.workdir}/.ttnt"
-    FileUtils.rm_rf(@storage_file)
+    File.delete(@storage_file)
 
     @metadata = TTNT::MetaData.new(@repo, nil)
     @name = 'anchored_sha'

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -6,7 +6,7 @@ class MetaDataTest < TTNT::TestCase
     @storage_file = "#{@repo.workdir}/.ttnt"
     FileUtils.rm_rf(@storage_file)
 
-    @metadata = TTNT::MetaData.new(@repo)
+    @metadata = TTNT::MetaData.new(@repo, nil)
     @name = 'anchored_sha'
     @value = 'abcdef'
   end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'ttnt/metadata'
+
+class MetaDataTest < TTNT::TestCase
+  def setup
+    @storage_file = "#{@repo.workdir}/.ttnt"
+    FileUtils.rm_rf(@storage_file)
+
+    @metadata = TTNT::MetaData.new(@repo)
+    @name = 'anchored_sha'
+    @value = 'abcdef'
+  end
+
+  def test_get_metadata
+    File.write(@storage_file, { 'meta' => { @name => @value} }.to_json)
+    assert @metadata.get(@name).nil?, '#get should not read from file.'
+    @metadata.read!
+    assert_equal @value, @metadata.get(@name)
+  end
+
+  def test_write_metadata
+    @metadata.set(@name, @value)
+    @metadata.write!
+    expected = { 'meta' => { @name => @value } }
+    assert_equal expected, JSON.parse(File.read(@storage_file))
+  end
+end

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -6,7 +6,7 @@ class MetaDataTest < TTNT::TestCase
     @storage_file = "#{@repo.workdir}/.ttnt"
     File.delete(@storage_file)
 
-    @metadata = TTNT::MetaData.new(@repo, nil)
+    @metadata = TTNT::MetaData.new(@repo)
     @name = 'anchored_sha'
     @value = 'abcdef'
   end

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'ttnt/storage'
+
+class StorageTest < TTNT::TestCase
+  def setup
+    @storage_file = "#{@repo.workdir}/.ttnt"
+    FileUtils.rm_rf(@storage_file)
+
+    @section = 'test'
+    @storage = TTNT::Storage.new(@repo)
+    @data = { 'a' => 1, 'b' => 2 }
+  end
+
+  def test_read_storage
+    File.write(@storage_file, { @section => @data }.to_json)
+    assert_equal @data, @storage.read(@section)
+  end
+
+  def test_write_storage
+    @storage.write!(@section, @data)
+    assert File.exist?(@storage_file), 'Storage file should be created.'
+    assert_equal @data, JSON.parse(File.read(@storage_file))[@section]
+  end
+end

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -16,9 +16,25 @@ class StorageTest < TTNT::TestCase
     assert_equal @data, @storage.read(@section)
   end
 
+  def test_read_storage_from_history
+    @storage.write!(@section, @data)
+    git_commit_am('Add data to storage file')
+    sha = @repo.head.target_id
+    new_data = { 'c' => 3 }
+    @storage.write!(@section, new_data) # write to a file in working tree
+    history_storage = TTNT::Storage.new(@repo, sha)
+    assert_equal @data, history_storage.read(@section)
+  end
+
   def test_write_storage
     @storage.write!(@section, @data)
     assert File.exist?(@storage_file), 'Storage file should be created.'
     assert_equal @data, JSON.parse(File.read(@storage_file))[@section]
+  end
+
+  def test_cannot_write_to_history_storage
+    sha = @repo.head.target_id
+    history_storage = TTNT::Storage.new(@repo, sha)
+    assert_raises { history_storage.write!(@section, @data) }
   end
 end

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -23,7 +23,8 @@ class StorageTest < TTNT::TestCase
     new_data = { 'c' => 3 }
     @storage.write!(@section, new_data) # write to a file in working tree
     history_storage = TTNT::Storage.new(@repo, sha)
-    assert_equal @data, history_storage.read(@section)
+    assert !history_storage.read(@section).key?('c'),
+      'History storage should not contain data from current working directory.'
   end
 
   def test_write_storage

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -4,7 +4,7 @@ require 'ttnt/storage'
 class StorageTest < TTNT::TestCase
   def setup
     @storage_file = "#{@repo.workdir}/.ttnt"
-    FileUtils.rm_rf(@storage_file)
+    File.delete(@storage_file)
 
     @section = 'test'
     @storage = TTNT::Storage.new(@repo)

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -19,11 +19,6 @@ class TestToCodeMappingTest < TTNT::TestCase
     assert_equal expected_mapping, @test_to_code_mapping.read_mapping
   end
 
-  def test_save_commit_info
-    @test_to_code_mapping.save_commit_info(@repo.head.target_id)
-    assert_equal @repo.head.target_id, File.read("#{@repo.workdir}/.ttnt/commit_obj.txt")
-  end
-
   def test_get_tests
     test_file = 'test/fizz_test.rb'
     coverage = { "#{@repo.workdir}/lib/fizzbuzz.rb"=> [1, 1, nil, 1, 0, 1, 0, 1] }

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -5,7 +5,7 @@ class TestToCodeMappingTest < TTNT::TestCase
   def setup
     # clean up generated .ttnt files
     FileUtils.rm_rf("#{@repo.workdir}/.ttnt")
-    @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo)
+    @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo, nil)
   end
 
   def test_append_from_coverage

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -4,7 +4,7 @@ require 'ttnt/test_to_code_mapping'
 class TestToCodeMappingTest < TTNT::TestCase
   def setup
     # clean up generated .ttnt files
-    FileUtils.rm_rf("#{@repo.workdir}/.ttnt")
+    File.delete("#{@repo.workdir}/.ttnt")
     @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo, nil)
   end
 

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -5,7 +5,7 @@ class TestToCodeMappingTest < TTNT::TestCase
   def setup
     # clean up generated .ttnt files
     File.delete("#{@repo.workdir}/.ttnt")
-    @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo, nil)
+    @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo)
   end
 
   def test_append_from_coverage


### PR DESCRIPTION
Implementation of #21 

I changed the saving mechanism from saving to separated file under `.ttnt` directory to saving to a single file named `.ttnt`.

Since I did not like to touch the same file from many places across the application, I made these changes:

- created `TTNT::Storage` class, which is responsible for IO with the `.ttnt` file
- created `TTNT::Metadata` class, which uses `TTNT::Storage` to store and retrieve metadata
- made `TTNT::TestToCodeMapping` use `TTNT::Storage` to save mappings to the `.ttnt` file

`TTNT::Storage` can have `sections`, which corresponds to the top level key of JSON object in `.ttnt` file (i.e. if `.ttnt` has `{ 'meta': {...}, 'mapping': {...} }`, there are 'meta' and 'mapping' sections).

And since we should be able to read file contents from a given commit on the git history (e.g. when a user ran `rake ttnt:test:anchor` and `.ttnt` file on current working tree is changed and the user runs `rake ttnt:test:run`, the mapping should be read from `.ttnt` file from the commit `HEAD` points to), I made it possible here: https://github.com/Genki-S/ttnt/commit/c2909fdcc93032760837503dc7e91b6c9c56dade
(which is actually a generalization of the logic [here](https://github.com/Genki-S/ttnt/pull/25/files#diff-c2993c7789d2d14196b4b1b184845358L76))

@robin850 could you review the code please?

(I have some refactoring other than these changes, so I will make another PR for those once this gets merged)