### PR TITLE
Refactoring regarding changes in #25

### DIFF
--- a/lib/ttnt/anchor.rb
+++ b/lib/ttnt/anchor.rb
@@ -13,6 +13,8 @@ at_exit do
   sha = repo.head.target_id
   mapping = TTNT::TestToCodeMapping.new(repo)
   mapping.append_from_coverage(test_file, Coverage.result)
+  mapping.write!
+
   metadata = TTNT::MetaData.new(repo)
   metadata['anchored_commit'] = sha
   metadata.write!

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -11,9 +11,8 @@ module TTNT
 
     # @param repo [Rugged::Reposiotry] repository of the project
     # @param target_sha [String] sha of the target object
-    # @param base_sha [String] sha of the base object
     # @param test_files [#include?] candidate test files
-    def initialize(repo, target_sha, base_sha, test_files)
+    def initialize(repo, target_sha, test_files)
       @repo = repo
       @metadata = MetaData.new(repo, target_sha)
       @target_obj = @repo.lookup(target_sha)

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -57,18 +57,16 @@ module TTNT
     end
 
     # Define a task which runs only tests which might have affected from changes
-    # in BASE_SHA...TARGET_SHA
+    # between anchored commit and TARGET_SHA.
     #
-    # TARGET_SHA and BASE_SHA can be specified as an environment variable. They
-    # defaults to HEAD and merge base between master and TARGET_SHA, respectively.
+    # TARGET_SHA can be specified as an environment variable (defaults to HEAD).
     #
     # @return [void]
     def define_run_task
       desc @run_description
       task 'run' do
         target_sha = ENV['TARGET_SHA'] || repo.head.target_id
-        base_sha = ENV['BASE_SHA'] || repo.merge_base(target_sha, repo.rev_parse('master'))
-        ts = TTNT::TestSelector.new(repo, target_sha, base_sha, expanded_file_list)
+        ts = TTNT::TestSelector.new(repo, target_sha, expanded_file_list)
         tests = ts.select_tests!
         if tests.empty?
           STDERR.puts 'No test selected.'

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -11,7 +11,7 @@ module TTNT
     end
 
     def test_mapping_generation
-      mapping = TTNT::TestToCodeMapping.new(@repo, @repo.head.target_id).read_mapping
+      mapping = TTNT::TestToCodeMapping.new(@repo, @repo.head.target_id).mapping
       expected_mapping = {"test/buzz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 6, 7]},
                           "test/fizz_test.rb"=>{"lib/fizzbuzz.rb"=>[1, 2, 4, 5]}}
       assert_equal expected_mapping, mapping

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -6,9 +6,8 @@ module TTNT
     def setup
       target_sha = @repo.branches['change_fizz'].target.oid
       master_sha = @repo.branches['master'].target.oid
-      base_sha = @repo.merge_base(target_sha, master_sha)
       @test_files = Rake::FileList['test/**/*_test.rb']
-      @selector = TTNT::TestSelector.new(@repo, target_sha, base_sha, @test_files)
+      @selector = TTNT::TestSelector.new(@repo, target_sha, @test_files)
     end
 
     def test_base_obj_selection
@@ -29,8 +28,7 @@ module TTNT
       git_commit_am('Change buzz_test')
       target_sha = @repo.head.target_id
       master_sha = @repo.branches['master'].target.oid
-      base_sha = @repo.merge_base(target_sha, master_sha)
-      selector = TTNT::TestSelector.new(@repo, target_sha, base_sha, @test_files)
+      selector = TTNT::TestSelector.new(@repo, target_sha, @test_files)
       assert_includes selector.select_tests!, 'test/buzz_test.rb'
     end
   end

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -16,7 +16,7 @@ class TestToCodeMappingTest < TTNT::TestCase
     expected_mapping = {
       test_file => { 'lib/fizzbuzz.rb' => [1, 2, 4, 6, 8] }
     }
-    assert_equal expected_mapping, @test_to_code_mapping.read_mapping
+    assert_equal expected_mapping, @test_to_code_mapping.mapping
   end
 
   def test_get_tests


### PR DESCRIPTION
I made some refactoring regarding changes in #25 

- Made `TTNT::TestToCodeMapping` store mapping data on memory, and made `#read!` and `#write!` method interact with `TTNT::Storage`: https://github.com/Genki-S/ttnt/commit/510cb66497cf8c2bdec584b5f0b06e9a4b5d272f
- Made `TTNT::TestSelector` not take `base_sha` as an argument, since it can determine base sha (i.e. the sha of anchored commit) by reading metadata: https://github.com/Genki-S/ttnt/commit/14957be5733d7cab3e5be1a3f91d8fdab866cee0

@robin850 could you review the code please?