### PR TITLE
Set target sha as current working tree

### DIFF
--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -16,7 +16,7 @@ module TTNT
     def initialize(repo, target_sha, test_files)
       @repo = repo
       @metadata = MetaData.new(repo, target_sha)
-      @target_obj = target_sha ? @repo.lookup(target_sha) : nil
+      @target_obj = @repo.lookup(target_sha) if target_sha
 
       # Base should be the commit `ttnt:anchor` has run on.
       # NOT the one test-to-code mapping was commited to.

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -65,7 +65,7 @@ module TTNT
     def define_run_task
       desc @run_description
       task 'run' do
-        target_sha = ENV['TARGET_SHA'] || nil
+        target_sha = ENV['TARGET_SHA']
         ts = TTNT::TestSelector.new(repo, target_sha, expanded_file_list)
         tests = ts.select_tests!
         if tests.empty?

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -65,7 +65,7 @@ module TTNT
     def define_run_task
       desc @run_description
       task 'run' do
-        target_sha = ENV['TARGET_SHA'] || repo.head.target_id
+        target_sha = ENV['TARGET_SHA'] || nil
         ts = TTNT::TestSelector.new(repo, target_sha, expanded_file_list)
         tests = ts.select_tests!
         if tests.empty?

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -27,5 +27,14 @@ module TTNT
       output = rake('ttnt:test:run')
       assert_match '1 runs, 1 assertions, 1 failures', output[:stdout]
     end
+
+    def test_tests_are_selected_based_on_changes_in_current_working_tree
+      @repo.checkout('change_fizz')
+      # Change buzz too
+      fizzbuzz_file = "#{@repo.workdir}/lib/fizzbuzz.rb"
+      File.write(fizzbuzz_file, File.read(fizzbuzz_file).gsub(/"buzz"$/, '"bar"'))
+      output = rake('ttnt:test:run')
+      assert_match '2 runs, 2 assertions, 2 failures', output[:stdout]
+    end
   end
 end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -27,7 +27,7 @@ module TTNT
       fizzbuzz_file = "#{@repo.workdir}/lib/fizzbuzz.rb"
       File.write(fizzbuzz_file, File.read(fizzbuzz_file).gsub(/"buzz"$/, '"bar"'))
       selector = TTNT::TestSelector.new(@repo, nil, @test_files)
-      assert_equal selector.select_tests!, Set.new(['test/fizz_test.rb', 'test/buzz_test.rb'])
+      assert_equal Set.new(['test/fizz_test.rb', 'test/buzz_test.rb']), selector.select_tests!
     end
 
     def test_selects_tests_with_changed_test_file

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -21,6 +21,15 @@ module TTNT
       assert_equal ['test/fizz_test.rb'], @selector.tests.to_a
     end
 
+    def test_selects_tests_from_current_working_tree
+      @repo.checkout('change_fizz')
+      # Change buzz too
+      fizzbuzz_file = "#{@repo.workdir}/lib/fizzbuzz.rb"
+      File.write(fizzbuzz_file, File.read(fizzbuzz_file).gsub(/"buzz"$/, '"bar"'))
+      selector = TTNT::TestSelector.new(@repo, nil, @test_files)
+      assert_equal selector.select_tests!, Set.new(['test/fizz_test.rb', 'test/buzz_test.rb'])
+    end
+
     def test_selects_tests_with_changed_test_file
       buzz_test = "#{@repo.workdir}/test/buzz_test.rb"
       File.write(buzz_test, File.read(buzz_test) + "\n") # meaningless change


### PR DESCRIPTION
Implementation of #26 

Currently, running `rake ttnt:test:run` selects and run tests based on diff between anchored commit and HEAD commit.
This PR changes it to select and run tests based on diff between anchored commit and current working tree. This is useful since users can change their code and see the result by running `rake ttnt:test:run` before committing that change.

@robin850 could you review the code please?