### PR TITLE
Run all tests when no mapping ('.ttnt' file) is found

### DIFF
--- a/lib/ttnt/storage.rb
+++ b/lib/ttnt/storage.rb
@@ -54,7 +54,12 @@ module TTNT
 
     def read_storage_content
       if @sha
-        @repo.lookup(@repo.lookup(@sha).tree['.ttnt'][:oid]).content
+        tree = @repo.lookup(@sha).tree
+        if tree['.ttnt']
+          @repo.lookup(@repo.lookup(@sha).tree['.ttnt'][:oid]).content
+        else
+          '' # Storage file is not committed for the commit of given sha
+        end
       else
         File.exist?(filename) ? File.read(filename) : ''
       end

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -15,7 +15,8 @@ module TTNT
     # @param test_files [#include?] candidate test files
     def initialize(repo, target_sha, test_files)
       @repo = repo
-      @metadata = MetaData.new(repo, target_sha)
+      storage_src_sha = target_sha ? target_sha : @repo.head.target_id
+      @metadata = MetaData.new(repo, storage_src_sha)
       @target_obj = @repo.lookup(target_sha) if target_sha
 
       # Base should be the commit `ttnt:anchor` has run on.

--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -30,7 +30,9 @@ module TTNT
     #
     # @return [Set] a set of tests that might be affected by changes in base_sha...target_sha
     def select_tests!
-      # TODO: if test-to-code-mapping is not found (ttnt-anchor has not been run)
+      # select all tests if anchored commit does not exist
+      return Set.new(@test_files) unless @base_obj
+
       @tests ||= Set.new
       diff = @target_obj ? @base_obj.diff(@target_obj) : @base_obj.diff_workdir
       diff.each_patch do |patch|
@@ -83,7 +85,11 @@ module TTNT
 
     # Find the commit `rake ttnt:test:anchor` has been run on.
     def find_anchored_commit
-      @repo.lookup(@metadata['anchored_commit'])
+      if @metadata['anchored_commit']
+        @repo.lookup(@metadata['anchored_commit'])
+      else
+        nil
+      end
     end
 
     # Check if given file is a test file.

--- a/test/helpers/git_helper.rb
+++ b/test/helpers/git_helper.rb
@@ -21,6 +21,13 @@ module TTNT
       git_commit(index, message)
     end
 
+    def git_rm_and_commit(file, message)
+      index = @repo.index
+      index.read_tree(@repo.head.target.tree) unless @repo.empty?
+      index.remove(file.gsub(/^#{@repo.workdir}\//, ''))
+      git_commit(index, message)
+    end
+
     def git_checkout_b(branch)
       @repo.create_branch(branch)
       @repo.checkout(branch)

--- a/test/helpers/git_helper.rb
+++ b/test/helpers/git_helper.rb
@@ -2,22 +2,23 @@ module TTNT
   module GitHelper
     module_function
 
-    def git_commit_am(message)
-      index   = @repo.index
+    def git_commit(index, message)
       options = {}
-
-      index.read_tree(@repo.head.target.tree) unless @repo.empty?
-      index.add_all
-
       options[:tree]       = index.write_tree(@repo)
       options[:author]     = { email: "foo@bar.com", name: 'Author', time: Time.now }
       options[:committer]  = options[:author]
       options[:message]    = message
       options[:parents]    = @repo.empty? ? [] : [@repo.head.target].compact
       options[:update_ref] = 'HEAD'
-
       Rugged::Commit.create(@repo, options)
       index.write
+    end
+
+    def git_commit_am(message)
+      index = @repo.index
+      index.read_tree(@repo.head.target.tree) unless @repo.empty?
+      index.add_all
+      git_commit(index, message)
     end
 
     def git_checkout_b(branch)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -25,8 +25,9 @@ module TTNT
 
       def test_all_tests_are_selected_without_mapping
         git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt')
-        output = rake('ttnt:test:run')
-        assert_match '2 runs, 6 assertions, 0 failures', output[:stdout]
+        rake_ttnt_result = rake('ttnt:test:run')[:stdout].lines.last
+        rake_test_result = rake('test')[:stdout].lines.last
+        assert_equal rake_test_result, rake_ttnt_result
       end
 
       def test_fizz_test_is_selected

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -23,6 +23,12 @@ module TTNT
         assert_equal "", output[:stdout]
       end
 
+      def test_all_tests_are_selected_without_mapping
+        git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt')
+        output = rake('ttnt:test:run')
+        assert_match '2 runs, 6 assertions, 0 failures', output[:stdout]
+      end
+
       def test_fizz_test_is_selected
         @repo.checkout('change_fizz')
         output = rake('ttnt:test:run')

--- a/test/storage_test.rb
+++ b/test/storage_test.rb
@@ -27,6 +27,12 @@ class StorageTest < TTNT::TestCase::FizzBuzz
       'History storage should not contain data from current working directory.'
   end
 
+  def test_read_absent_storage_from_history
+    git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt file')
+    storage = TTNT::Storage.new(@repo, @repo.head.target_id)
+    assert_equal Hash.new, storage.read(@section)
+  end
+
   def test_write_storage
     @storage.write!(@section, @data)
     assert File.exist?(@storage_file), 'Storage file should be created.'

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -40,5 +40,11 @@ module TTNT
       selector = TTNT::TestSelector.new(@repo, target_sha, @test_files)
       assert_includes selector.select_tests!, 'buzz_test.rb'
     end
+
+    def test_selects_all_tests_with_no_anchored_commit
+      git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt file')
+      selector = TTNT::TestSelector.new(@repo, @repo.head.target_id, @test_files)
+      assert_equal Set.new(['fizz_test.rb', 'buzz_test.rb']), selector.select_tests!
+    end
   end
 end


### PR DESCRIPTION
Currently, running `rake ttnt:test:run` without having '.ttnt' file available (i.e. not running `rake ttnt:test:anchor` previously) leads to an error.

I changed this behavior so that TTNT runs all tests when '.ttnt' file is not available. The core change is implemented in this commit: [Make TestSelector select all tests if anchored commit does not exist · Genki-S/ttnt@4426d05](https://github.com/Genki-S/ttnt/commit/4426d0515e4bf65b5caed503bf5e74409992771f)

@robin850 could you review the code please?

P.S. I'm currently trying to use TTNT in Rails ActionMailer. I'll appreciate it if you could check an email I sent to you with subject "[Rails GSoC] About the goal of my project".