### PR TITLE
Isolated test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ If you defined TTNT rake task as described above, you can run following command 
 $ rake ttnt:my_test_name:run
 ```
 
+#### Options
+
+You can run test files one by one by setting `ISOLATED` environment variable:
+
+```
+$ rake ttnt:my_test_name:run ISOLATED=1
+```
+
+With isolated option, you can set `FAIL_FAST` environment variable to stop running successive tests after a test has failed:
+
+```
+$ rake ttnt:my_test_name:run ISOLATED=1 FAIL_FAST=1
+```
+
 ## Current Limitations
 
 - Test selection algorithm is not perfect yet (it may produce false-positives and false-negatives)

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -75,6 +75,7 @@ module TTNT
             tests.each do |test|
               args = "#{@rake_testtask.ruby_opts_string} #{test} #{@rake_testtask.option_list}"
               run_ruby args
+              break if @failed && ENV['FAIL_FAST']
             end
           else
             args =
@@ -117,6 +118,7 @@ module TTNT
     # @param args [String] argument to pass to ruby
     def run_ruby(args)
       ruby "#{args}" do |ok, status|
+        @failed = true if !ok
         if !ok && status.respond_to?(:signaled?) && status.signaled?
           raise SignalException.new(status.termsig)
         end

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -71,10 +71,17 @@ module TTNT
         if tests.empty?
           STDERR.puts 'No test selected.'
         else
-          args =
-            "#{@rake_testtask.ruby_opts_string} #{@rake_testtask.run_code} " +
-            "#{tests.to_a.join(' ')} #{@rake_testtask.option_list}"
-          run_ruby args
+          if ENV['ISOLATED']
+            tests.each do |test|
+              args = "#{@rake_testtask.ruby_opts_string} #{test} #{@rake_testtask.option_list}"
+              run_ruby args
+            end
+          else
+            args =
+              "#{@rake_testtask.ruby_opts_string} #{@rake_testtask.run_code} " +
+              "#{tests.to_a.join(' ')} #{@rake_testtask.option_list}"
+            run_ruby args
+          end
         end
       end
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -44,6 +44,15 @@ module TTNT
         output = rake('ttnt:test:run')
         assert_match '2 runs, 2 assertions, 2 failures', output[:stdout]
       end
+
+      def test_isolated
+        # Make TTNT select all tests
+        git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt')
+        ENV['ISOLATED'] = '1'
+        output = rake('ttnt:test:run')
+        ENV.delete('ISOLATED')
+        assert_equal 3, output[:stdout].split('# Running:').count
+      end
     end
 
     class AdditionAmongComments < TTNT::TestCase::AdditionAmongComments

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -53,6 +53,18 @@ module TTNT
         ENV.delete('ISOLATED')
         assert_equal 3, output[:stdout].split('# Running:').count
       end
+
+      def test_isolated_with_fail_fast
+        @repo.checkout('change_fizz')
+        fizzbuzz_file = "#{@repo.workdir}/fizzbuzz.rb"
+        File.write(fizzbuzz_file, File.read(fizzbuzz_file).gsub(/"buzz"$/, '"bar"'))
+        ENV['ISOLATED'] = '1'
+        ENV['FAIL_FAST'] = '1'
+        output = rake('ttnt:test:run')
+        ENV.delete('ISOLATED')
+        ENV.delete('FAIL_FAST')
+        assert_equal 2, output[:stdout].split('Failure:').count
+      end
     end
 
     class AdditionAmongComments < TTNT::TestCase::AdditionAmongComments

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -50,8 +50,9 @@ module TTNT
         git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt')
         ENV['ISOLATED'] = '1'
         output = rake('ttnt:test:run')
-        ENV.delete('ISOLATED')
         assert_equal 3, output[:stdout].split('# Running:').count
+      ensure
+        ENV.delete('ISOLATED')
       end
 
       def test_isolated_with_fail_fast
@@ -61,9 +62,10 @@ module TTNT
         ENV['ISOLATED'] = '1'
         ENV['FAIL_FAST'] = '1'
         output = rake('ttnt:test:run')
+        assert_equal 2, output[:stdout].split('Failure:').count
+      ensure
         ENV.delete('ISOLATED')
         ENV.delete('FAIL_FAST')
-        assert_equal 2, output[:stdout].split('Failure:').count
       end
     end
 


### PR DESCRIPTION
This is just an idea I got when I was trying to run TTNT in railties.

It seems tests in railties should be run one by one. So, it might be good to add an option to TTNT which makes it possible to run selected tests one by one.

I implemented the isolated run and it can be enabled by setting `ISOLATED` environment variable (https://github.com/Genki-S/ttnt/commit/012d484ed1fea259b61427b3460fe104be939303). And I also implemented "fail fast" feature in isolated run with which TTNT stops on first failure. It can be enabled by setting `FAIL_FAST` environment variable (https://github.com/Genki-S/ttnt/commit/27d1712b200a81d32a109cee59b4e2b948d865ac).

So, usage would be like `$ rake ttnt:test:run ISOLATED=1` or `$ rake ttnt:test:run ISOLATED=1 FAIL_FAST=1`.

This might be a little hack-ish (it might be better to provide setting option usable in Rakefile rather than environment variables).
@robin850 what do you think?