### PR TITLE
Add `code_files` and `test_files` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,29 +58,43 @@ Or install it yourself as:
 
     $ gem install ttnt
 
-### Define rake tasks
+### Define Rake tasks
 
-You can define TTNT rake tasks by following steps:
+TTNT allows you to define its tasks according to an existing `Rake::TestTask` object like:
 
-1. `require 'ttnt/testtask'`
-2. Define `TTNT::TestTask` when defining `Rake::TestTask`
-
-Your `Rakefile` will look like this:
-
-```
+```ruby
 require 'rake/testtask'
 require 'ttnt/testtask'
 
-Rake::TestTask.new { |t|
-  t.name = 'my_test_name'
+t = Rake::TestTask.new do |t|
   t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  TTNT::TestTask.new(t)
-}
+  t.name = 'task_name'
+end
+
+TTNT::TestTask.new(t)
 ```
 
-This will define 2 rake tasks `ttnt:my_test_name:anchor` and `ttnt:my_test_name:run` (portion of `my_test_name` depends on the name you specify for your `Rake::TestTask`).
-Usage for those tasks are described later in this document.
+This will define 2 tasks: `ttnt:task_name:anchor` and `ttnt:task_name:run`. Usage for those tasks are described later in this document.
+
+You can also instantiate a new `TTNT::TestTask` object and specify certain options like:
+
+```ruby
+require 'ttnt/testtask'
+
+TTNT::TestTask.new do |t|
+  t.code_files = FileList['lib/**/*.rb'] - FileList['lib/vendor/**/*.rb']
+  t.test_files = 'test/**/*_test.rb'
+end
+```
+
+Available options are as follows:
+
+- `name`
+  - Specifies task name.
+- `code_files`
+  - Specifies code files TTNT uses to select tests. Changes in files not listed here do not affect the test selection. Defaults to all files under the directory `Rakefile` resides.
+- `test_files`
+  - Specifies test files. Defaults to the default value of `Rake::TestTask`.
 
 ## Requirements
 
@@ -92,7 +106,7 @@ Developed and only tested under ruby version 2.2.2.
 
 If you defined TTNT rake task as described above, you can run following command to produce test-to-code mapping:
 
-```
+```sh
 $ rake ttnt:my_test_name:anchor
 ```
 
@@ -100,7 +114,7 @@ $ rake ttnt:my_test_name:anchor
 
 If you defined TTNT rake task as described above, you can run following command to run selected tests.
 
-```
+```sh
 $ rake ttnt:my_test_name:run
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,11 @@ TTNT::TestTask.new do |t|
 end
 ```
 
-Available options are as follows:
+You can specify the same options as `Rake::TestTask`.
+Additionally, there is an option which is specific to TTNT:
 
-- `name`
-  - Specifies task name.
 - `code_files`
   - Specifies code files TTNT uses to select tests. Changes in files not listed here do not affect the test selection. Defaults to all files under the directory `Rakefile` resides.
-- `test_files`
-  - Specifies test files. Defaults to the default value of `Rake::TestTask`.
 
 ## Requirements
 

--- a/lib/ttnt/test_to_code_mapping.rb
+++ b/lib/ttnt/test_to_code_mapping.rb
@@ -63,6 +63,17 @@ module TTNT
       tests
     end
 
+    # Select (filter) code files from mapping by given file names.
+    #
+    # @param code_files [#include?] code file names to filter
+    def select_code_files!(code_files)
+      @mapping.map do |test, spectra|
+        spectra.select! do |code, lines|
+          code_files.include?(code)
+        end
+      end
+    end
+
     private
 
     # Convert absolute path to relative path from the project (Git repository) root.

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -16,6 +16,7 @@ module TTNT
     # An instance of `Rake::TestTask` passed when TTNT::TestTask is initialized
     attr_accessor :rake_testtask
 
+    attr_accessor :name
     attr_reader :test_files
     attr_reader :code_files
 
@@ -32,12 +33,16 @@ module TTNT
     # @param rake_testtask [Rake::TestTask] an instance of Rake::TestTask after user configuration is done
     def initialize(rake_testtask = nil)
       @rake_testtask = rake_testtask || Rake::TestTask.new
-      # Since test_files is not exposed in Rake::TestTask
-      @test_files = @rake_testtask.instance_variable_get('@test_files')
 
+      # Make configurations consistent between TTNT::TestTask and Rake::TestTask
+      # 1. Copy options from @rake_testtask to self
+      @test_files = @rake_testtask.instance_variable_get('@test_files')
+      @name = @rake_testtask.name
+      # 2. Execute configuration block
       yield self if block_given?
-      # Apply configuration from given block to @rake_testtask
+      # 3. Apply configuration from given block back to @rake_testtask
       @rake_testtask.test_files = @test_files
+      @rake_testtask.name = @name
 
       @anchor_description = 'Generate test-to-code mapping' + (@rake_testtask.name == :test ? '' : " for #{@rake_testtask.name}")
       @run_description = 'Run selected tests' + (@rake_testtask.name == :test ? '' : "for #{@rake_testtask.name}")

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -1,5 +1,6 @@
 require 'rugged'
 require 'rake'
+require 'rake/testtask'
 require 'ttnt/test_selector'
 
 module TTNT
@@ -18,8 +19,8 @@ module TTNT
     # Create an instance of TTNT::TestTask and define TTNT rake tasks.
     #
     # @param rake_testtask [Rake::TestTask] an instance of Rake::TestTask after user configuration is done
-    def initialize(rake_testtask)
-      @rake_testtask = rake_testtask
+    def initialize(rake_testtask = nil)
+      @rake_testtask = rake_testtask || Rake::TestTask.new
       # Since test_files is not exposed in Rake::TestTask
       @test_files = @rake_testtask.instance_variable_get('@test_files')
 

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -16,6 +16,9 @@ module TTNT
     # An instance of `Rake::TestTask` passed when TTNT::TestTask is initialized
     attr_accessor :rake_testtask
 
+    attr_accessor :test_files
+    attr_accessor :code_files
+
     # Create an instance of TTNT::TestTask and define TTNT rake tasks.
     #
     # @param rake_testtask [Rake::TestTask] an instance of Rake::TestTask after user configuration is done
@@ -23,6 +26,10 @@ module TTNT
       @rake_testtask = rake_testtask || Rake::TestTask.new
       # Since test_files is not exposed in Rake::TestTask
       @test_files = @rake_testtask.instance_variable_get('@test_files')
+
+      yield self if block_given?
+      # Apply configuration from given block to @rake_testtask
+      @rake_testtask.test_files = @test_files
 
       @anchor_description = 'Generate test-to-code mapping' + (@rake_testtask.name == :test ? '' : " for #{@rake_testtask.name}")
       @run_description = 'Run selected tests' + (@rake_testtask.name == :test ? '' : "for #{@rake_testtask.name}")

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -16,8 +16,16 @@ module TTNT
     # An instance of `Rake::TestTask` passed when TTNT::TestTask is initialized
     attr_accessor :rake_testtask
 
-    attr_accessor :test_files
-    attr_accessor :code_files
+    attr_reader :test_files
+    attr_reader :code_files
+
+    def code_files=(files)
+      @code_files = files.kind_of?(String) ? FileList[files] : files
+    end
+
+    def test_files=(files)
+      @test_files = files.kind_of?(String) ? FileList[files] : files
+    end
 
     # Create an instance of TTNT::TestTask and define TTNT rake tasks.
     #

--- a/lib/ttnt/testtask.rb
+++ b/lib/ttnt/testtask.rb
@@ -122,6 +122,12 @@ module TTNT
             run_ruby "#{args} #{test_file}"
           end
         end
+
+        if @code_files
+          mapping = TestToCodeMapping.new(repo)
+          mapping.select_code_files!(@code_files)
+          mapping.write!
+        end
       end
     end
 

--- a/test/fixtures/fizzbuzz_multicode/Rakefile
+++ b/test/fixtures/fizzbuzz_multicode/Rakefile
@@ -1,0 +1,8 @@
+require 'ttnt/testtask'
+
+TTNT::TestTask.new do |t|
+  t.test_files = ['fizz_test.rb', 'buzz_test.rb', 'fizzbuzz_test.rb']
+  t.code_files = ['fizz_detectable.rb', 'buzz_detectable.rb', 'fizzbuzz_detectable.rb']
+end
+
+task :default => :test

--- a/test/fixtures/fizzbuzz_multicode/all_test.rb
+++ b/test/fixtures/fizzbuzz_multicode/all_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require_relative './fizzbuzz'
+
+class TestAll < Minitest::Test
+  def test_all
+    fb = FizzBuzz.new
+    assert_equal "fizz", fb.convert(3)
+    assert_equal "buzz", fb.convert(5)
+    assert_equal "fizzbuzz", fb.convert(15)
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/buzz_detectable.rb
+++ b/test/fixtures/fizzbuzz_multicode/buzz_detectable.rb
@@ -1,0 +1,8 @@
+module BuzzDetectable
+
+  module_function
+
+  def buzz?(n)
+    n % 5 == 0
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/buzz_test.rb
+++ b/test/fixtures/fizzbuzz_multicode/buzz_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require_relative './fizzbuzz'
+
+class TestBuzz < Minitest::Test
+  def test_buzz
+    fb = FizzBuzz.new
+    assert_equal "buzz", fb.convert(5)
+    assert_equal "buzz", fb.convert(10)
+    assert_equal "buzz", fb.convert(20)
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/fizz_detectable.rb
+++ b/test/fixtures/fizzbuzz_multicode/fizz_detectable.rb
@@ -1,0 +1,8 @@
+module FizzDetectable
+
+  module_function
+
+  def fizz?(n)
+    n % 3 == 0
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/fizz_test.rb
+++ b/test/fixtures/fizzbuzz_multicode/fizz_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require_relative './fizzbuzz'
+
+class TestFizz < Minitest::Test
+  def test_fizz
+    fb = FizzBuzz.new
+    assert_equal "fizz", fb.convert(3)
+    assert_equal "fizz", fb.convert(6)
+    assert_equal "fizz", fb.convert(9)
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/fizzbuzz.rb
+++ b/test/fixtures/fizzbuzz_multicode/fizzbuzz.rb
@@ -1,0 +1,21 @@
+require_relative './fizz_detectable'
+require_relative './buzz_detectable'
+require_relative './fizzbuzz_detectable'
+
+class FizzBuzz
+  include FizzDetectable
+  include BuzzDetectable
+  include FizzBuzzDetectable
+
+  def convert(n)
+    if fizzbuzz?(n)
+      "fizzbuzz"
+    elsif buzz?(n)
+      "buzz"
+    elsif fizz?(n)
+      "fizz"
+    else
+      n
+    end
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/fizzbuzz_detectable.rb
+++ b/test/fixtures/fizzbuzz_multicode/fizzbuzz_detectable.rb
@@ -1,0 +1,8 @@
+module FizzBuzzDetectable
+
+  module_function
+
+  def fizzbuzz?(n)
+    n % 15 == 0
+  end
+end

--- a/test/fixtures/fizzbuzz_multicode/fizzbuzz_test.rb
+++ b/test/fixtures/fizzbuzz_multicode/fizzbuzz_test.rb
@@ -1,0 +1,11 @@
+require 'minitest/autorun'
+require_relative './fizzbuzz'
+
+class TestFizzBuzz < Minitest::Test
+  def test_fizzbuzz
+    fb = FizzBuzz.new
+    assert_equal "fizzbuzz", fb.convert(15)
+    assert_equal "fizzbuzz", fb.convert(30)
+    assert_equal "fizzbuzz", fb.convert(45)
+  end
+end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -109,5 +109,20 @@ module TTNT
         assert_match '1 runs, 1 assertions, 1 failures', output[:stdout]
       end
     end
+
+    class FizzBuzzMultiCode < TTNT::TestCase::FizzBuzzMultiCode
+      def test_code_files_option
+        fn = 'fizzbuzz.rb'
+        File.write(fn, File.read(fn).gsub(/"fizzbuzz"$/, "foo"))
+        output = rake('ttnt:test:run')
+        assert_match 'No test selected.', output[:stderr],
+          'Changing files which is not specified in code_files should not select tests.'
+
+        fn = 'fizz_detectable.rb'
+        File.write(fn, File.read(fn).gsub(/n % 3 == 0$/, "n % 3 == 1"))
+        output = rake('ttnt:test:run')
+        assert_match "Failure:\nTestFizz#test_fizz", output[:stdout]
+      end
+    end
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -116,7 +116,7 @@ module TTNT
         File.write(fn, File.read(fn).gsub(/"fizzbuzz"$/, "foo"))
         output = rake('ttnt:test:run')
         assert_match 'No test selected.', output[:stderr],
-          'Changing files which is not specified in code_files should not select tests.'
+          'Changing files which are not specified in code_files should not select any tests.'
 
         fn = 'fizz_detectable.rb'
         File.write(fn, File.read(fn).gsub(/n % 3 == 0$/, "n % 3 == 1"))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -124,5 +124,16 @@ module TTNT
         # do nothing
       end
     end
+
+    class FizzBuzzMultiCode < Base
+      def fixture_dir
+        File.join(__dir__, 'fixtures/fizzbuzz_multicode')
+      end
+
+      private
+
+      def after_preparing_git_repository
+      end
+    end
   end
 end

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -29,4 +29,10 @@ class TestToCodeMappingTest < TTNT::TestCase::FizzBuzz
     assert_equal Set.new([@test_file]),
       @test_to_code_mapping.get_tests(file: 'fizzbuzz.rb', lineno: 2)
   end
+
+  def test_select_code_files
+    @test_to_code_mapping.select_code_files!([])
+    assert_equal Set.new([]),
+      @test_to_code_mapping.get_tests(file: 'fizzbuzz.rb', lineno: 3)
+  end
 end

--- a/test/test_to_code_mapping_test.rb
+++ b/test/test_to_code_mapping_test.rb
@@ -6,30 +6,27 @@ class TestToCodeMappingTest < TTNT::TestCase::FizzBuzz
     # clean up generated .ttnt files
     File.delete("#{@repo.workdir}/.ttnt")
     @test_to_code_mapping = TTNT::TestToCodeMapping.new(@repo)
+    @test_file = 'fizz_test.rb'
+    # Not a valid coverage, but an example
+    @coverage = { "#{@repo.workdir}/fizzbuzz.rb"=> [1, 1, nil, 1, 0, 1, 0, 1, 0] }
+    @test_to_code_mapping.append_from_coverage(@test_file, @coverage)
   end
 
   def test_append_from_coverage
-    test_file = 'fizz_test.rb'
-    # Not a valid coverage, but an example
-    coverage = { "#{@repo.workdir}/fizzbuzz.rb"=> [1, 1, nil, 1, 0, 1, 0, 1] }
-    @test_to_code_mapping.append_from_coverage(test_file, coverage)
     expected_mapping = {
-      test_file => { 'fizzbuzz.rb' => [1, 2, 4, 6, 8] }
+      @test_file => { 'fizzbuzz.rb' => [1, 2, 4, 6, 8] }
     }
     assert_equal expected_mapping, @test_to_code_mapping.mapping
   end
 
   def test_get_tests
-    test_file = 'fizz_test.rb'
-    coverage = { "#{@repo.workdir}/fizzbuzz.rb"=> [1, 1, nil, 1, 0, 1, 0, 1, 0] }
-    @test_to_code_mapping.append_from_coverage(test_file, coverage)
-    assert_equal Set.new([test_file]),
+    assert_equal Set.new([@test_file]),
       @test_to_code_mapping.get_tests(file: 'fizzbuzz.rb', lineno: 3),
       'It should select tests if the specified line is between the topmost executed line and downmost executed line in coverage'
     assert_equal Set.new([]),
       @test_to_code_mapping.get_tests(file: 'fizzbuzz.rb', lineno: 9),
       'It should not select tests if the specified line is not between the topmost executed line and downmost executed line in coverage'
-    assert_equal Set.new([test_file]),
+    assert_equal Set.new([@test_file]),
       @test_to_code_mapping.get_tests(file: 'fizzbuzz.rb', lineno: 2)
   end
 end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -40,13 +40,13 @@ class TestTaskTest < Minitest::Test
   end
 
   def test_yield_and_configure
-    test_files = ['foo_test.rb', 'bar_test.rb']
+    test_files = 'foo_test'
     code_files = ['foo.rb', 'bar.rb']
     ttnt_task = TTNT::TestTask.new { |t|
       t.test_files = test_files
       t.code_files = code_files
     }
-    assert_equal test_files, ttnt_task.test_files
+    assert_equal FileList[test_files], ttnt_task.test_files
     assert_equal code_files, ttnt_task.code_files
   end
 end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -36,7 +36,7 @@ class TestTaskTest < Minitest::Test
   def test_instance_without_passing_rake_task
     default_rake_task = Rake::TestTask.new
     ttnt_task = TTNT::TestTask.new
-    assert_equal default_rake_task.name, ttnt_task.instance_variable_get(:@rake_testtask).name
+    assert ttnt_task.instance_variable_get(:@rake_testtask).kind_of?(Rake::TestTask)
   end
 
   def test_yield_and_configure

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -40,12 +40,16 @@ class TestTaskTest < Minitest::Test
   end
 
   def test_yield_and_configure
+    name = 'testname'
     test_files = 'foo_test'
     code_files = ['foo.rb', 'bar.rb']
     ttnt_task = TTNT::TestTask.new { |t|
+      t.name = name
       t.test_files = test_files
       t.code_files = code_files
     }
+    assert Rake::Task.task_defined?("ttnt:#{name}:anchor"),
+      "`ttnt:#{name}:anchor` task should be defined"
     assert_equal FileList[test_files], ttnt_task.test_files
     assert_equal code_files, ttnt_task.code_files
   end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -32,4 +32,10 @@ class TestTaskTest < Minitest::Test
     test_files = Rake::FileList['test/**/*_test.rb'] + ['test/dummy_test.rb']
     assert_equal test_files, @ttnt_task.expanded_file_list
   end
+
+  def test_instance_without_passing_rake_task
+    default_rake_task = Rake::TestTask.new
+    ttnt_task = TTNT::TestTask.new
+    assert_equal default_rake_task.name, ttnt_task.instance_variable_get(:@rake_testtask).name
+  end
 end

--- a/test/testtask_test.rb
+++ b/test/testtask_test.rb
@@ -38,4 +38,15 @@ class TestTaskTest < Minitest::Test
     ttnt_task = TTNT::TestTask.new
     assert_equal default_rake_task.name, ttnt_task.instance_variable_get(:@rake_testtask).name
   end
+
+  def test_yield_and_configure
+    test_files = ['foo_test.rb', 'bar_test.rb']
+    code_files = ['foo.rb', 'bar.rb']
+    ttnt_task = TTNT::TestTask.new { |t|
+      t.test_files = test_files
+      t.code_files = code_files
+    }
+    assert_equal test_files, ttnt_task.test_files
+    assert_equal code_files, ttnt_task.code_files
+  end
 end


### PR DESCRIPTION
Implementation of an idea discussed in #5 

In order to make it possible to narrow the target of test and code files, I implemented the idea of providing `code_files` option discussed in #5 .

Usage is like this:

```
TTNT::TestTask.new do |t|
  t.test_files = FileList['**/*_test.rb']
  t.code_files = FileList['lib/**/*.rb'] - FileList['lib/vendor/**/*.rb']
end
```

I took an approach to filter generated mapping after `anchor` task is finished. Filtering method is added by [this commit (Implement `TestToCodeMapping#select_code_files!)](https://github.com/Genki-S/ttnt/commit/fb47020b38aebc0b0adccb2edae4cc10bbfc905d) and the use of the method is added in [this commit (Filter mapping based on code_files option after anchoring)](https://github.com/Genki-S/ttnt/commit/2c55d988f06d16994d5a1c58fa276aa776b796ab).

@robin850 could you review the code please?