### PR TITLE
Take new test files (untracked files) into account

### DIFF
--- a/lib/ttnt/test_selector.rb
+++ b/lib/ttnt/test_selector.rb
@@ -35,7 +35,11 @@ module TTNT
       return Set.new(@test_files) unless @base_obj
 
       @tests ||= Set.new
-      diff = @target_obj ? @base_obj.diff(@target_obj) : @base_obj.diff_workdir
+      opts = {
+        include_untracked: true,
+        recurse_untracked_dirs: true
+      }
+      diff = @target_obj ? @base_obj.diff(@target_obj, opts) : @base_obj.diff_workdir(opts)
       diff.each_patch do |patch|
         file = patch.delta.old_file[:path]
         if test_file?(file)

--- a/test/fixtures/fizzbuzz/Rakefile
+++ b/test/fixtures/fizzbuzz/Rakefile
@@ -2,7 +2,7 @@ require 'rake/testtask'
 require 'ttnt/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.pattern = '*_test.rb'
+  t.pattern = '**/*_test.rb'
   TTNT::TestTask.new(t)
 end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -67,6 +67,15 @@ module TTNT
         ENV.delete('ISOLATED')
         ENV.delete('FAIL_FAST')
       end
+
+      def test_select_untracked_files
+        FileUtils.mkdir('test')
+        fizz_test = './fizz_test.rb'
+        File.write(fizz_test, File.read(fizz_test).gsub("require_relative '\.", "require_relative '.."))
+        FileUtils.mv('./fizz_test.rb', './test/fizz_test.rb')
+        output = rake('ttnt:test:run')
+        assert_match '1 runs, 3 assertions, 0 failures', output[:stdout]
+      end
     end
 
     class AdditionAmongComments < TTNT::TestCase::AdditionAmongComments

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -72,7 +72,7 @@ module TTNT
         FileUtils.mkdir('test')
         fizz_test = './fizz_test.rb'
         File.write(fizz_test, File.read(fizz_test).gsub("require_relative '\.", "require_relative '.."))
-        FileUtils.mv('./fizz_test.rb', './test/fizz_test.rb')
+        FileUtils.mv(fizz_test, './test/fizz_test.rb')
         output = rake('ttnt:test:run')
         assert_match '1 runs, 3 assertions, 0 failures', output[:stdout]
       end

--- a/test/test_selector_test.rb
+++ b/test/test_selector_test.rb
@@ -6,7 +6,7 @@ module TTNT
     def setup
       target_sha = @repo.branches['change_fizz'].target.oid
       master_sha = @repo.branches['master'].target.oid
-      @test_files = Rake::FileList['*_test.rb']
+      @test_files = Rake::FileList['**/*_test.rb']
       @selector = TTNT::TestSelector.new(@repo, target_sha, @test_files)
     end
 
@@ -45,6 +45,14 @@ module TTNT
       git_rm_and_commit("#{@repo.workdir}/.ttnt", 'Remove .ttnt file')
       selector = TTNT::TestSelector.new(@repo, @repo.head.target_id, @test_files)
       assert_equal Set.new(['fizz_test.rb', 'buzz_test.rb']), selector.select_tests!
+    end
+
+    def test_selects_untracked_test_files
+      FileUtils.mkdir('test')
+      new_test = 'test/new_test.rb'
+      FileUtils.touch(new_test)
+      selector = TTNT::TestSelector.new(@repo, nil, @test_files)
+      assert_equal Set.new([new_test]), selector.select_tests!
     end
   end
 end


### PR DESCRIPTION
Currently, untracked files are not listed in the diff generated by `Rugged::Commit#diff{,_workdir}` method. So, TTNT cannot run untracked test files in cases like (1) new test file is added and (2) a test file is renamed.

This PR solves this problem by using `include_untracked` and `recurse_untracked_dirs` options for `Rugged::{Tree,Commit}#diff{,_workdir}` method. Descriptions from [ext/rugged/rugged_tree.c](https://github.com/libgit2/rugged/blob/295900c8a85582129a42d04e66d72ef9eeb75ea1/ext/rugged/rugged_tree.c#L357-L476):

```
*  :include_untracked ::
 *   If true, untracked files will be included in the diff.

*  :recurse_untracked_dirs ::
 *    Even if +:include_untracked+ is true, untracked directories will only be
 *    marked with a single entry in the diff. If this flag is set to true,
 *    all files under ignored directories will be included in the diff, too.
```

@robin850 could you review the code please?